### PR TITLE
Fixes setApplicationEntityManager call

### DIFF
--- a/Command/MigrationsDiffDoctrineCommand.php
+++ b/Command/MigrationsDiffDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand;
 
 /**
@@ -37,7 +38,7 @@ class MigrationsDiffDoctrineCommand extends DiffCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsExecuteDoctrineCommand.php
+++ b/Command/MigrationsExecuteDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
 
 /**
@@ -36,7 +37,7 @@ class MigrationsExecuteDoctrineCommand extends ExecuteCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsGenerateDoctrineCommand.php
+++ b/Command/MigrationsGenerateDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 
 /**
@@ -36,7 +37,7 @@ class MigrationsGenerateDoctrineCommand extends GenerateCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsMigrateDoctrineCommand.php
+++ b/Command/MigrationsMigrateDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
 
 /**
@@ -36,7 +37,7 @@ class MigrationsMigrateDoctrineCommand extends MigrateCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsStatusDoctrineCommand.php
+++ b/Command/MigrationsStatusDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand;
 
 /**
@@ -36,7 +37,7 @@ class MigrationsStatusDoctrineCommand extends StatusCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsVersionDoctrineCommand.php
+++ b/Command/MigrationsVersionDoctrineCommand.php
@@ -14,6 +14,7 @@ namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 
 /**
@@ -36,7 +37,7 @@ class MigrationsVersionDoctrineCommand extends VersionCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommand::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);


### PR DESCRIPTION
'setApplicationEntityManager' method has moved from DoctrineComand to DoctrinerHelperCommand.
This commit just fixes calls to setApplicationEntityManager to make DoctrineMigrationsBundle simply work.
