### PR TITLE
Install documentation fixes

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -29,6 +29,7 @@ and the doctrine-migrations library as dependencies in your application:
     [DoctrineMigrationsBundle]
         git=http://github.com/symfony/DoctrineMigrationsBundle.git
         target=/bundles/Symfony/Bundle/DoctrineMigrationsBundle
+        version=origin/2.0
 
 Update the vendor libraries:
 


### PR DESCRIPTION
I struggled a bit when trying to install this bundle yesterday... I think both pages of the documentation are wrong. This pull request fixes this page http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html .
Regarding this page : http://symfony.com/doc/master/bundles/DoctrineMigrationsBundle/index.html , I think something misses in autoload.php, and I tried specifying an array of folders to make the Doctrine namespace correspond to both the bundle and the doctrine library. I didn't get it to work though, so no pull request for this one...
