### PR TITLE
Container aware migrations

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -40,13 +40,13 @@ abstract class DoctrineCommand extends BaseCommand
         $configuration->setName($container->getParameter('doctrine_migrations.name'));
         $configuration->setMigrationsTableName($container->getParameter('doctrine_migrations.table_name'));
         
-        $this->injectContainerToMigrations($container, $configuration->getMigrations());
+        self::injectContainerToMigrations($container, $configuration->getMigrations());
     }
 
     /**
      * Injects the container to migrations aware of it
      */
-    private function injectContainerToMigrations(ContainerInterface $container, array $versions)
+    private static function injectContainerToMigrations(ContainerInterface $container, array $versions)
     {
         foreach ($versions as $version) {
             $migration = $version->getMigration();


### PR DESCRIPTION
This would allow much more powerful migrations as right now all you can do is SQL stuff.

Moved from https://github.com/symfony/DoctrineMigrationsBundle/pull/2
