### PR TITLE
Fix namespace to doctrine in links

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -283,4 +283,4 @@ schema fully up to date. In fact, this is an easy and dependable workflow
 for your project.
 
 .. _documentation: http://www.doctrine-project.org/projects/migrations/2.0/docs/reference/introduction/en
-.. _DoctrineMigrationsBundle: https://github.com/symfony/DoctrineMigrationsBundle
+.. _DoctrineMigrationsBundle: https://github.com/doctrine/DoctrineMigrationsBundle


### PR DESCRIPTION
In addition to this fix, it seems that documentation on symfony2 website got stuck in a version between 2.0 and master, 
http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html

```
[DoctrineMigrationsBundle]
    git=http://github.com/symfony/DoctrineMigrationsBundle.git
    target=/bundles/Symfony/Bundle/DoctrineMigrationsBundle
    version=origin/2.0
```
