### PR TITLE
2.0

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -25,7 +25,13 @@ abstract class DoctrineCommand extends BaseCommand
 {
     public static function configureMigrations(ContainerInterface $container, Configuration $configuration)
     {
-        $dir = $container->getParameter('doctrine_migrations.dir_name');
+        // Attempt to grab the migrations directory from a configuration file first. If not defined,
+        // use the one from the primary configuration file or the default one.
+        $dir = $configuration->getMigrationsDirectory();
+        if (empty($dir)) {
+            $dir = $container->getParameter('doctrine_migrations.dir_name');
+        }
+
         if (!file_exists($dir)) {
             mkdir($dir, 0777, true);
         }


### PR DESCRIPTION
The Doctrine Migrations help from the command line says you can pass in a configuration file to indicate the location that the migrations should be saved and executed from. However, it didn't appear that works. The actual doctrine-migrations library supports this, however the Bundle seems to ignore whatever the doctrine-migrations library uses for the configuration directory and instead uses the doctrine_migrations.dir_name configuration value.

Unfortunately, that doesn't work well because the doctrine-migrations library does not work with doctrine_migrations.dir_name, it wants migrations_directory in the configuration. Thus this change allows you to point to a specific directory from a configuration file to tell the library where to manage your migrations from.

This works if you have several bundles under the same Symfony installation and each of them have completely different databases and configuration.

Another alternative would to just have a --dir option that you pass in to indicate where migrations should be run from.
