### PR TITLE
Bug fix

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -16,7 +16,7 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand as BaseCommand;
+use Symfony\Bundle\DoctrineBundle\Command\DoctrineCommand as BaseCommand;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
 /**


### PR DESCRIPTION
It fixs "Fatal error: Class 'Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand' not found in vendor/bundles/Doctrine/Bundle/MigrationsBundle/Command/DoctrineCommand.php on line 28"
