### PR TITLE
Issue #38 Multiple entity managers support

### DIFF
--- a/Command/MigrationsDiffDoctrineCommand.php
+++ b/Command/MigrationsDiffDoctrineCommand.php
@@ -44,7 +44,11 @@ class MigrationsDiffDoctrineCommand extends DiffCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/Command/MigrationsExecuteDoctrineCommand.php
+++ b/Command/MigrationsExecuteDoctrineCommand.php
@@ -43,7 +43,11 @@ class MigrationsExecuteDoctrineCommand extends ExecuteCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/Command/MigrationsGenerateDoctrineCommand.php
+++ b/Command/MigrationsGenerateDoctrineCommand.php
@@ -43,7 +43,11 @@ class MigrationsGenerateDoctrineCommand extends GenerateCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/Command/MigrationsMigrateDoctrineCommand.php
+++ b/Command/MigrationsMigrateDoctrineCommand.php
@@ -43,7 +43,11 @@ class MigrationsMigrateDoctrineCommand extends MigrateCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/Command/MigrationsStatusDoctrineCommand.php
+++ b/Command/MigrationsStatusDoctrineCommand.php
@@ -43,7 +43,11 @@ class MigrationsStatusDoctrineCommand extends StatusCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/Command/MigrationsVersionDoctrineCommand.php
+++ b/Command/MigrationsVersionDoctrineCommand.php
@@ -43,7 +43,11 @@ class MigrationsVersionDoctrineCommand extends VersionCommand
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
 
         $configuration = $this->getMigrationConfiguration($input, $output);
-        DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);
+        DoctrineCommand::configureMigrations(
+            $this->getApplication()->getKernel()->getContainer(),
+            $configuration,
+            $input->getOption('em')
+        );
 
         parent::execute($input, $output);
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,23 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('doctrine_migrations', 'array');
 
         $rootNode
+            ->beforeNormalization()
+                ->ifTrue(function($v) {
+                    if(empty($v)) {
+                        return true;
+                    }
+                    $firstConfigValue = array_shift($v);
+
+                    return !is_array($firstConfigValue);
+                })
+                ->then(function($v) {
+                    $v = array('default_entity_manager' => $v);
+
+                    return $v;
+                })
+            ->end()
+            ->useAttributeAsKey('name')
+            ->prototype('array')
             ->children()
                 ->scalarNode('dir_name')->defaultValue('%kernel.root_dir%/DoctrineMigrations')->cannotBeEmpty()->end()
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | NA
| Fixed tickets | #38
| License       | MIT

This PR is an attempt to solve #38 by allowing to specify a different migrations config per entity manager. This feature is targeted at people who use multiple databases for a single Symfony2 project.

As an example :

```yaml
doctrine_migrations:
    em1:
        dir_name: %kernel.root_dir%/DoctrineMigrations/Em1
        namespace: Application\Migrations\Em1
    em2:
        dir_name: %kernel.root_dir%/DoctrineMigrations/Em2
        namespace: Application\Migrations\Em2
```

Notes : 

*  This additional level of nesting in the config is totally optional, the standard way still works
* An exception is thrown in 2 cases : 
  * If the config file is defined on a per-entity manager basis but no --em option is provided 
  * If there is no config entry defined for the provided --em option

Thoughts ?