### PR TITLE
Docs: Annotation must integer instead of string for length

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -217,7 +217,7 @@ for Doctrine's ORM:
             protected $id;
 
             /**
-             * @ORM\Column(type="string", length="255")
+             * @ORM\Column(type="string", length=255)
              */
             protected $name;
         }


### PR DESCRIPTION
Small fix for the docs for those that like to copy/paste code.

This should also be patched into the master branch.
