### PR TITLE
Support for specifying migrations manually

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -12,7 +12,6 @@
 namespace Symfony\Bundle\DoctrineMigrationsBundle\Command;
 
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Bundle\DoctrineBundle\Command\DoctrineCommand as BaseCommand;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 
@@ -35,5 +34,9 @@ abstract class DoctrineCommand extends BaseCommand
         $configuration->registerMigrationsFromDirectory($dir);
         $configuration->setName($container->getParameter('doctrine_migrations.name'));
         $configuration->setMigrationsTableName($container->getParameter('doctrine_migrations.table_name'));
+
+        foreach ($container->getParameter('doctrine_migrations.migrations') as $migration) {
+            $configuration->registerMigration($migration['version'], $migration['class']);
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,6 +27,14 @@ class Configuration
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
+                ->arrayNode('migrations')
+                    ->prototype('array')
+                        ->children()
+                            ->scalarNode('version')->isRequired()->end()
+                            ->scalarNode('class')->isRequired()->end()
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 


### PR DESCRIPTION
According to current [documentation](http://docs.doctrine-project.org/projects/doctrine-migrations/en/latest/reference/introduction.html#configuration) it is possible to add each migration manually. This change allows adding migrations in bundle configuration as well as manipulating them (e.g. through symfony2 compilerPass).
