### PR TITLE
Update DoctrineMigrationsBundle requirements

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,6 +23,7 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
+            "doctrine/migrations": "dev-master",
             "doctrine/doctrine-migrations-bundle": "dev-master"
         }
     }


### PR DESCRIPTION
When you are trying to install the DoctrineMigrationsBundle, from raw Symfony version, if you just follow the online documentation, adding:
{
    "require": {
        "doctrine/doctrine-migrations-bundle": "dev-master"
    }
}

You can get this error:
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for doctrine/doctrine-migrations-bundle dev-master -> satisfiable by doctrine/doctrine-migrations-bundle[dev-master].
    - doctrine/doctrine-migrations-bundle dev-master requires doctrine/migrations ~1.0@dev -> no matching package found.
  Problem 2
    - doctrine/doctrine-migrations-bundle dev-master requires doctrine/migrations ~1.0@dev -> no matching package found.
    - symfony/framework-standard-edition 2.3.x-dev requires doctrine/doctrine-migrations-bundle dev-master -> satisfiable by doctrine/doctrine-migrations-bundle[dev-master].
    - Installation request for symfony/framework-standard-edition 2.3.x-dev -> satisfiable by symfony/framework-standard-edition[2.3.x-dev].

To solve this dependency problem, should add the following line to composer.json:
"doctrine/migrations": "dev-master"

It's nice to show to the user the dependencies too
