### PR TITLE
 DoctrineMigrationsBundle installation, fix composer.json

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,6 +23,7 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
+            "doctrine/migrations": "dev-master",
             "doctrine/doctrine-migrations-bundle": "dev-master"
         }
     }


### PR DESCRIPTION
As referred here doctrine/DoctrineMigrationsBundle#54 in order to install doctrine migrations with "stable" minimum stability, you need to define both doctrine/migrations and doctrine/doctrine-migrations-bundle at dev-master
