### PR TITLE
Bundle migrations feature

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -40,14 +40,18 @@ abstract class DoctrineCommand extends BaseCommand
         $configuration->setName($container->getParameter('doctrine_migrations.name'));
         $configuration->setMigrationsTableName($container->getParameter('doctrine_migrations.table_name'));
 
-        $bundleDirectory = str_replace("\\", "/", $configuration->getMigrationsNamespace());
-        $kernel = $container->get("kernel");
-        /* @var $kernel \Symfony\Component\HttpKernel\Kernel */
-        foreach ($kernel->getBundles() as $bundle) {
-            /* @var $bundle \Symfony\Component\HttpKernel\Bundle\Bundle */
-            $bundleDir = $bundle->getPath() . "/" . $bundleDirectory;
-            if (file_exists($bundleDir) && is_dir($bundleDir)) {
-                $configuration->registerMigrationsFromDirectory($bundleDir);
+        if ($container->getParameter('doctrine_migrations.use_bundles')) {
+            $migrationsDirectory = str_replace("\\", "/", $configuration->getMigrationsNamespace());
+            $kernel = $container->get("kernel");
+            /* @var $kernel \Symfony\Component\HttpKernel\Kernel */
+            $bundles = $container->getParameter('doctrine_migrations.bundles');
+            foreach ($bundles as $bundleName) {
+                $bundle = $kernel->getBundle($bundleName);
+                /* @var $bundle \Symfony\Component\HttpKernel\Bundle\Bundle */
+                $bundleDir = $bundle->getPath() . "/" . $migrationsDirectory;
+                if (file_exists($bundleDir) && is_dir($bundleDir)) {
+                    $configuration->registerMigrationsFromDirectory($bundleDir);
+                }
             }
         }
         self::injectContainerToMigrations($container, $configuration->getMigrations());

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -24,6 +24,22 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  */
 class Configuration implements ConfigurationInterface
 {
+
+    /**
+     * @var array
+     */
+    private $_bundles;
+
+    /**
+     * Constructor
+     *
+     * @param array $bundles An array of bundle names
+     */
+    public function __construct(array $bundles)
+    {
+        $this->_bundles = $bundles;
+    }
+
     /**
      * Generates the configuration tree.
      *
@@ -40,6 +56,16 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
+                ->booleanNode('use_bundles')->defaultValue(false)->end()
+                ->arrayNode('bundles')
+                    ->defaultValue($this->_bundles)
+                    ->prototype('scalar')
+                        ->validate()
+                            ->ifNotInArray($this->_bundles)
+                            ->thenInvalid('%s is not a valid bundle.')
+                        ->end()
+                    ->end()
+                ->end()
             ->end()
         ;
 

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -32,7 +32,10 @@ class DoctrineMigrationsExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
+        $bundles = array_keys(
+            $container->getParameter('kernel.bundles')
+        );
+        $configuration = new Configuration($bundles);
 
         $config = $this->processConfiguration($configuration, $configs);
 


### PR DESCRIPTION
This will allow to extend a list of migrations in `app/Application/Migrations` with migrations inside bundles directories. This feature is optional and it is disabled by default. A list of bundles with migrations is configurable, by default this list contains all application bundles.

Bundle migrations must be stored in `[bundleDir]/Application/Migrations` directory and use the same namespace as application migrations in `app/Application/Migrations` directory.

Additional configuration:

```
doctrine_migrations:
    use_bundles: true           # Enable feature
    bundles: [ '...', '...' ]   # Configure a list of bundles with migrations
```
