### PR TITLE
Add doctrine/migrations to composer.json

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,6 +23,7 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
+            "doctrine/migrations": "dev-master",
             "doctrine/doctrine-migrations-bundle": "dev-master"
         }
     }


### PR DESCRIPTION
If you dont specify this in composer.json, you get a "your requirements can't be satisfied". Tested right now with a fresh install of Symfony 2.3.7 Standard Distribution
