### PR TITLE
Member properties of parameter $configuration of class Configuraiton are overwritten in method configureMigrations in class DoctrineCommand (Issue #81)

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -29,18 +29,51 @@ abstract class DoctrineCommand extends BaseCommand
 {
     public static function configureMigrations(ContainerInterface $container, Configuration $configuration)
     {
-        $dir = $container->getParameter('doctrine_migrations.dir_name');
-        if (!file_exists($dir)) {
-            mkdir($dir, 0777, true);
+        
+        if ($configuration->getMigrationsDirectory() == null || $configuration->getMigrationsDirectory() == '') 
+        {
+            $dir = $container->getParameter('doctrine_migrations.dir_name');
+            if (!file_exists($dir)) 
+            {
+                mkdir($dir, 0777, true);
+            }
+            $configuration->setMigrationsDirectory($dir);
+            $configuration->registerMigrationsFromDirectory($dir);
         }
-
-        $configuration->setMigrationsNamespace($container->getParameter('doctrine_migrations.namespace'));
-        $configuration->setMigrationsDirectory($dir);
-        $configuration->registerMigrationsFromDirectory($dir);
-        $configuration->setName($container->getParameter('doctrine_migrations.name'));
-        $configuration->setMigrationsTableName($container->getParameter('doctrine_migrations.table_name'));
+        else
+        {
+            $dir = $configuration->getMigrationsDirectory();
+            // class Kernel has method getKernelParameters with some of the important path parameters
+            $pathPlaceholderArray = array('kernel.root_dir', 'kernel.cache_dir', 'kernel.logs_dir');
+            foreach ($pathPlaceholderArray as $pathPlaceholder)
+            {
+                if ($container->hasParameter($pathPlaceholder) && preg_match('/\%'.$pathPlaceholder.'\%/', $dir)) 
+                {
+                    $dir = str_replace('%'.$pathPlaceholder.'%', $container->getParameter($pathPlaceholder), $dir);
+                }
+            }
+            if (!file_exists($dir)) 
+            {
+                mkdir($dir, 0777, true);
+            }
+            $configuration->setMigrationsDirectory($dir);
+            $configuration->registerMigrationsFromDirectory($dir);
+        }
+        if ($configuration->getMigrationsNamespace() == null || $configuration->getMigrationsNamespace() == '')
+        {
+            $configuration->setMigrationsNamespace($container->getParameter('doctrine_migrations.namespace'));
+        }
+        if ($configuration->getName() == null || $configuration->getName() == '')
+        {
+            $configuration->setName($container->getParameter('doctrine_migrations.name'));
+        }
+        if ($configuration->getMigrationsTableName() == null || $configuration->getMigrationsTableName() == '')
+        {
+            $configuration->setMigrationsTableName($container->getParameter('doctrine_migrations.table_name'));
+        }
         
         self::injectContainerToMigrations($container, $configuration->getMigrations());
+        
     }
 
     /**


### PR DESCRIPTION
Bugfix of an old problem, which had not been fixed by a pull request yet.
Member properties of parameter $configuration of class Configuraiton are overwritten in method configureMigrations in class DoctrineCommand (Issue #81):
If someone explicitly uses the command line option --configuration along the doctrine:migrations:generate or doctrine:migrations:migrate commands to set a separate configuration file (e.g. a yaml-file with entries: name, migrations_namespace, table_name, migrations_directory), then it is correctly loaded by method load of class AbstractFileConfiguration and in turn read e.g. by the method doLoad of class YamlConfiguration from the yaml-file.
In method configureMigrations(ContainerInterface $container, Configuration $configuration) in class DoctrineCommand, however, these loaded configuration setting stored in the member properties of the parameter $configuration of class Configuration are set anew with the configuration settings in the app/config/config.yml file (with entries: dir_name, namespace, name, table_name).
The overwriting happens because there is no check whether the parameter $configuration already has set the member properties with a separate configuration file.
To me this appears to be a false implementation and should be fixed.
