### PR TITLE
Update requires

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -23,6 +23,7 @@ Standard edition. Add the following to your ``composer.json`` file:
 
     {
         "require": {
+            "doctrine/migrations": "1.0.*@dev",
             "doctrine/doctrine-migrations-bundle": "2.1.*@dev"
         }
     }


### PR DESCRIPTION
As it's a bad habit to rely on dev-master I guess it's better to use alias
- I removed doctrine/migrations because it is in the requires of migration bundle
