### PR TITLE
yaml is the correct lexer name

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -62,7 +62,7 @@ Configuration
 
 You can configure the path, namespace, table_name and name in your `config.yml`. The examples below are the default values.
 
-.. code-block:: yml
+.. code-block:: yaml
 
     // app/config/config.yml
     doctrine_migrations:


### PR DESCRIPTION
Hiya!

This will fix the lack of code highlighting here: http://symfony.com/doc/current/bundles/DoctrineMigrationsBundle/index.html#configuration

We're adding Travis build coverage to the official Symfony docs, which will include any of these core bundles included at symfony.com. So, merging this will be much appreciated, as it's causing Travis to fail currently :).

Thanks!
