### PR TITLE
Removing the erroneous example

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -322,8 +322,8 @@ to get full access to the container.
     
         public function postUp(Schema $schema)
         {
-            $em = $this->container->get('doctrine.orm.entity_manager');
-            // ... update the entities
+            $converter = $this->container->get('my_service.convert_data_to');
+            // ... convert the data from markdown to html for instance
         }
     }
 


### PR DESCRIPTION
Getting the EntityManager in the postUp method is flawed: if you have several unexecuted migrations in the project, the EntityManager will explode when using it in the postUp method of the first migration, because it will not run with entities matching this schema but with the latest version of entities.

https://github.com/doctrine/migrations/issues/124