### PR TITLE
Fix typo in documentation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -223,7 +223,7 @@ for Doctrine's ORM:
             protected $id;
 
             /**
-             * @ORM\Column(type="string", length="255")
+             * @ORM\Column(type="string", length=255)
              */
             protected $name;
         }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Doc fix?      | yes
| New docs?     | no
| Applies to    | all
| Fixed tickets |

In the part "Generating Migrations Automatically" there is a mapping
information sample for creating a new User entity. On the "Annotations"
tab the "name" property has a length of "255".

Having those double quotes around 255 is incorrect because running
"app/console doctrine:migrations:diff" throws an error. It expects
"length" to be an integer and not a string.

I removed the double quotes to prevent this error.