### PR TITLE
Allowed DoctrineMigrationsBundle to work with Symfony apps using DBAL only

### DIFF
--- a/Command/Helper/DoctrineCommandHelper.php
+++ b/Command/Helper/DoctrineCommandHelper.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Doctrine MigrationsBundle
+ *
+ * The code was originally distributed inside the Symfony framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ * (c) Doctrine Project, Guilehrme Blanco <guilhermeblanco@hotmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Doctrine\Bundle\MigrationsBundle\Command\Helper;
+
+use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper as BaseDoctrineCommandHelper;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+
+/**
+ * Provides some helper and convenience methods to configure doctrine commands in the context of bundles
+ * and multiple connections/entity managers.
+ *
+ * @author Guilherme Blanco <guilhermeblanco@hotmail.com>
+ */
+abstract class DoctrineCommandHelper extends BaseDoctrineCommandHelper
+{
+    public static function setApplicationHelper(Application $application, InputInterface $input)
+    {
+        $doctrine  = $application->getKernel()->getContainer()->get('doctrine');
+
+        if (empty($doctrine->getManagerNames())) {
+            self::setApplicationConnection($application, $input->getOption('db'));
+        } else {
+            self::setApplicationEntityManager($application, $input->getOption('em'));
+        }
+    }
+}

--- a/Command/MigrationsExecuteDoctrineCommand.php
+++ b/Command/MigrationsExecuteDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\ExecuteCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsExecuteDoctrineCommand extends ExecuteCommand
 
         $this
             ->setName('doctrine:migrations:execute')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsGenerateDoctrineCommand.php
+++ b/Command/MigrationsGenerateDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\GenerateCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsGenerateDoctrineCommand extends GenerateCommand
 
         $this
             ->setName('doctrine:migrations:generate')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsLatestDoctrineCommand.php
+++ b/Command/MigrationsLatestDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\LatestCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsLatestDoctrineCommand extends LatestCommand
 
         $this
             ->setName('doctrine:migrations:latest')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsMigrateDoctrineCommand.php
+++ b/Command/MigrationsMigrateDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\MigrateCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsMigrateDoctrineCommand extends MigrateCommand
 
         $this
             ->setName('doctrine:migrations:migrate')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsStatusDoctrineCommand.php
+++ b/Command/MigrationsStatusDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\StatusCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsStatusDoctrineCommand extends StatusCommand
 
         $this
             ->setName('doctrine:migrations:status')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsVersionDoctrineCommand.php
+++ b/Command/MigrationsVersionDoctrineCommand.php
@@ -17,7 +17,6 @@ namespace Doctrine\Bundle\MigrationsBundle\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputOption;
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\VersionCommand;
 
 /**
@@ -34,13 +33,19 @@ class MigrationsVersionDoctrineCommand extends VersionCommand
 
         $this
             ->setName('doctrine:migrations:version')
-            ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
+            ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+        // EM and DB options cannot be set at same time
+        if (null !== $input->getOption('em') && null !== $input->getOption('db')) {
+            throw new \InvalidArgumentException('Cannot set both "em" and "db" for command execution.');
+        }
+
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);


### PR DESCRIPTION
I also fixed a bug of accepting optional `--em` value (it should be required).