### PR TITLE
make the yaml comment syntax valid

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -64,7 +64,7 @@ You can configure the path, namespace, table_name and name in your `config.yml`.
 
 .. code-block:: yaml
 
-    // app/config/config.yml
+    # app/config/config.yml
     doctrine_migrations:
         dir_name: %kernel.root_dir%/DoctrineMigrations
         namespace: Application\Migrations

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -66,7 +66,7 @@ You can configure the path, namespace, table_name and name in your `config.yml`.
 
     # app/config/config.yml
     doctrine_migrations:
-        dir_name: %kernel.root_dir%/DoctrineMigrations
+        dir_name: "%kernel.root_dir%/DoctrineMigrations"
         namespace: Application\Migrations
         table_name: migration_versions
         name: Application Migrations   


### PR DESCRIPTION
`//` works in php, but does not mean anything in yaml