### PR TITLE
Add --shard option to migrations command

### DIFF
--- a/Command/Helper/DoctrineCommandHelper.php
+++ b/Command/Helper/DoctrineCommandHelper.php
@@ -15,6 +15,7 @@
 namespace Doctrine\Bundle\MigrationsBundle\Command\Helper;
 
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper as BaseDoctrineCommandHelper;
+use Doctrine\DBAL\Sharding\PoolingShardConnection;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 
@@ -28,13 +29,27 @@ abstract class DoctrineCommandHelper extends BaseDoctrineCommandHelper
 {
     public static function setApplicationHelper(Application $application, InputInterface $input)
     {
-        $doctrine  = $application->getKernel()->getContainer()->get('doctrine');
+        $container = $application->getKernel()->getContainer();
+        $doctrine  = $container->get('doctrine');
         $managerNames = $doctrine->getManagerNames();
 
         if (empty($managerNames)) {
             self::setApplicationConnection($application, $input->getOption('db'));
         } else {
             self::setApplicationEntityManager($application, $input->getOption('em'));
+        }
+
+        if ($input->getOption('shard')) {
+            $connection = $application->getHelperSet()->get('db')->getConnection();
+            if (!$connection instanceof PoolingShardConnection) {
+                if (empty($managerNames)) {
+                    throw new \LogicException(sprintf("Connection '%s' must implement shards configuration.", $input->getOption('db')));
+                } else {
+                    throw new \LogicException(sprintf("Connection of EntityManager '%s' must implement shards configuration.", $input->getOption('em')));
+                }
+            }
+
+            $connection->connect($input->getOption('shard'));
         }
     }
 }

--- a/Command/MigrationsDiffDoctrineCommand.php
+++ b/Command/MigrationsDiffDoctrineCommand.php
@@ -14,11 +14,12 @@
 
 namespace Doctrine\Bundle\MigrationsBundle\Command;
 
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand;
+use Doctrine\DBAL\Sharding\PoolingShardConnection;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Command for generate migration classes by comparing your current database schema
@@ -36,12 +37,22 @@ class MigrationsDiffDoctrineCommand extends DiffCommand
         $this
             ->setName('doctrine:migrations:diff')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
         DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
+
+        if ($input->getOption('shard')) {
+            $connection = $this->getApplication()->getHelperSet()->get('db')->getConnection();
+            if (!$connection instanceof PoolingShardConnection) {
+                throw new \LogicException(sprintf("Connection of EntityManager '%s' must implements shards configuration.", $input->getOption('em')));
+            }
+
+            $connection->connect($input->getOption('shard'));
+        }
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);

--- a/Command/MigrationsExecuteDoctrineCommand.php
+++ b/Command/MigrationsExecuteDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsExecuteDoctrineCommand extends ExecuteCommand
             ->setName('doctrine:migrations:execute')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 

--- a/Command/MigrationsGenerateDoctrineCommand.php
+++ b/Command/MigrationsGenerateDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsGenerateDoctrineCommand extends GenerateCommand
             ->setName('doctrine:migrations:generate')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 

--- a/Command/MigrationsLatestDoctrineCommand.php
+++ b/Command/MigrationsLatestDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsLatestDoctrineCommand extends LatestCommand
             ->setName('doctrine:migrations:latest')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 

--- a/Command/MigrationsMigrateDoctrineCommand.php
+++ b/Command/MigrationsMigrateDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsMigrateDoctrineCommand extends MigrateCommand
             ->setName('doctrine:migrations:migrate')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 

--- a/Command/MigrationsStatusDoctrineCommand.php
+++ b/Command/MigrationsStatusDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsStatusDoctrineCommand extends StatusCommand
             ->setName('doctrine:migrations:status')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 

--- a/Command/MigrationsVersionDoctrineCommand.php
+++ b/Command/MigrationsVersionDoctrineCommand.php
@@ -35,6 +35,7 @@ class MigrationsVersionDoctrineCommand extends VersionCommand
             ->setName('doctrine:migrations:version')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
+            ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
     }
 


### PR DESCRIPTION
This PR requires https://github.com/doctrine/dbal/pull/896, and is required by https://github.com/doctrine/DoctrineBundle/pull/456

- [x] Add `--shard` option to common migrations commands
- [x] Add `--shard` option to `doctrine:migrations:diff` command