### PR TITLE
Adding organize_migrations configuration

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand as BaseCommand;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 /**
  * Base class for Doctrine console commands to extend from.
@@ -63,6 +64,22 @@ abstract class DoctrineCommand extends BaseCommand
         // Migrations is not register from configuration loader
         if (!($configuration instanceof AbstractFileConfiguration)) {
             $configuration->registerMigrationsFromDirectory($configuration->getMigrationsDirectory());
+        }
+
+        if($container->hasParameter('doctrine_migrations.organize_migrations')){
+           $organizeMigrations = $container->getParameter('doctrine_migrations.organize_migrations');
+           switch($organizeMigrations){
+                case Configuration::VERSIONS_ORGANIZATION_BY_YEAR:
+                    $configuration->setMigrationsAreOrganizedByYear(true);
+                break;
+               case Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH:
+                    $configuration->setMigrationsAreOrganizedByYearAndMonth(true);
+                break;
+               case false:
+                   break;
+               default:
+                 throw new InvalidConfigurationException('Unrecognized option "'.$organizeMigrations.'" under "organize_migrations"');
+           }
         }
 
         self::injectContainerToMigrations($container, $configuration->getMigrations());

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,6 +40,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
+                ->scalarNode('organize_migrations')->defaultFalse()->end()
             ->end()
         ;
 


### PR DESCRIPTION
Just a pull request that allows the developer to use file organization feature from doctrine migrations by adding organize_migrations under doctrine_migrations. I am not sure if is that placed correctly but here it goes!