### PR TITLE
Added support of the organize migrations configuration.

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -14,12 +14,12 @@
 
 namespace Doctrine\Bundle\MigrationsBundle\Command;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Doctrine\Bundle\DoctrineBundle\Command\DoctrineCommand as BaseCommand;
-use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Doctrine\DBAL\Migrations\Configuration\AbstractFileConfiguration;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException;
 
 /**
  * Base class for Doctrine console commands to extend from.
@@ -63,6 +63,23 @@ abstract class DoctrineCommand extends BaseCommand
         // Migrations is not register from configuration loader
         if (!($configuration instanceof AbstractFileConfiguration)) {
             $configuration->registerMigrationsFromDirectory($configuration->getMigrationsDirectory());
+        }
+
+        $organizeMigrations = $container->getParameter('doctrine_migrations.organize_migrations');
+        switch ($organizeMigrations) {
+            case Configuration::VERSIONS_ORGANIZATION_BY_YEAR:
+                $configuration->setMigrationsAreOrganizedByYear(true);
+                break;
+
+            case Configuration::VERSIONS_ORGANIZATION_BY_YEAR_AND_MONTH:
+                $configuration->setMigrationsAreOrganizedByYearAndMonth(true);
+                break;
+
+            case false:
+                break;
+
+            default:
+                throw new InvalidArgumentException('Invalid value for "doctrine_migrations.organize_migrations" parameter.');
         }
 
         self::injectContainerToMigrations($container, $configuration->getMigrations());

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -27,12 +27,14 @@ class Configuration implements ConfigurationInterface
     /**
      * Generates the configuration tree.
      *
-     * @return \Symfony\Component\Config\Definition\Builder\TreeBuilder The config tree builder
+     * @return TreeBuilder The config tree builder
      */
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
         $rootNode = $treeBuilder->root('doctrine_migrations', 'array');
+
+        $organizeMigrationModes = $this->getOrganizeMigrationsModes();
 
         $rootNode
             ->children()
@@ -40,9 +42,55 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
+                ->scalarNode('organize_migrations')->defaultValue(false)
+                    ->info('Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false')
+                    ->validate()
+                        ->ifTrue(function ($v) use ($organizeMigrationModes) {
+                            if (false === $v) {
+                                return false;
+                            }
+
+                            if (is_string($v) && in_array(strtoupper($v), $organizeMigrationModes)) {
+                                return false;
+                            }
+
+                            return true;
+                        })
+                        ->thenInvalid('Invalid organize migrations mode value %s')
+                    ->end()
+                    ->validate()
+                        ->ifString()
+                            ->then(function ($v) {
+                                return constant('Doctrine\DBAL\Migrations\Configuration\Configuration::VERSIONS_ORGANIZATION_'.strtoupper($v));
+                            })
+                        ->end()
+                    ->end()
             ->end()
         ;
 
         return $treeBuilder;
+    }
+
+
+    /**
+     * Find organize migrations modes for their names
+     *
+     * @return array
+     */
+    private function getOrganizeMigrationsModes()
+    {
+        $constPrefix = 'VERSIONS_ORGANIZATION_';
+        $prefixLen = strlen($constPrefix);
+        $refClass = new \ReflectionClass('Doctrine\DBAL\Migrations\Configuration\Configuration');
+        $constsArray = $refClass->getConstants();
+        $namesArray = array();
+
+        foreach ($constsArray as $key => $value) {
+            if (strpos($key, $constPrefix) === 0) {
+                $namesArray[] = substr($key, $prefixLen);
+            }
+        }
+
+        return $namesArray;
     }
 }

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection;
+
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class DoctrineMigrationsExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testOrganizeMigrations()
+    {
+        $container = $this->getContainer();
+        $extension = new DoctrineMigrationsExtension();
+
+        $config = array(
+            'organize_migrations' => 'BY_YEAR',
+        );
+
+        $extension->load(array('doctrine_migrations' => $config), $container);
+
+        $this->assertEquals(Configuration::VERSIONS_ORGANIZATION_BY_YEAR, $container->getParameter('doctrine_migrations.organize_migrations'));
+    }
+
+    private function getContainer()
+    {
+        return new ContainerBuilder(new ParameterBag(array(
+            'kernel.debug' => false,
+            'kernel.bundles' => array(),
+            'kernel.cache_dir' => sys_get_temp_dir(),
+            'kernel.environment' => 'test',
+            'kernel.root_dir' => __DIR__.'/../../', // src dir
+        )));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.4.0",
         "symfony/framework-bundle": "~2.3|~3.0",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/migrations": "~1.0"
+        "doctrine/migrations": "^1.1"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,9 @@
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/migrations": "^1.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.8"
+    },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "" }
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit colors="true" bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="DoctrineMigrationsBundle for the Symfony Framework">
+            <directory>./Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>.</directory>
+            <exclude>
+                <directory>./Resources</directory>
+                <directory>./Tests</directory>
+                <directory>./vendor</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>


### PR DESCRIPTION
Untested yet. Alternative way for #145. @mikeSimonson I've used similar way like doctrine-bundle uses for proxy config generation.