### PR TITLE
var directory for symfony >= 2.8

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -38,7 +38,7 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->scalarNode('dir_name')->defaultValue('%kernel.root_dir%/DoctrineMigrations')->cannotBeEmpty()->end()
+                ->scalarNode('dir_name')->defaultValue('%kernel.root_dir%/../var/DoctrineMigrations')->cannotBeEmpty()->end()
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -87,7 +87,7 @@ the ``status`` command:
         >> Configuration Source:                               manually configured
         >> Version Table Name:                                 migration_versions
         >> Migrations Namespace:                               Application\Migrations
-        >> Migrations Directory:                               /path/to/project/app/DoctrineMigrations
+        >> Migrations Directory:                               /path/to/project/var/DoctrineMigrations
         >> Current Version:                                    0
         >> Latest Version:                                     0
         >> Executed Migrations:                                0
@@ -137,7 +137,7 @@ migration to execute:
        >> Configuration Source:                               manually configured
        >> Version Table Name:                                 migration_versions
        >> Migrations Namespace:                               Application\Migrations
-       >> Migrations Directory:                               /path/to/project/app/DoctrineMigrations
+       >> Migrations Directory:                               /path/to/project/var/DoctrineMigrations
        >> Current Version:                                    0
        >> Latest Version:                                     2010-06-21 14:06:55 (20100621140655)
        >> Executed Migrations:                                0
@@ -184,7 +184,7 @@ You can skip single migrations by explicitely adding them to the ``migration_ver
 
 .. code-block:: bash
 
-    $ php app/console doctrine:migrations:version YYYYMMDDHHMMSS --add
+    $ php bin/console doctrine:migrations:version YYYYMMDDHHMMSS --add
     
 Doctrine will then assume that this migration has already been run and will ignore it.
     


### PR DESCRIPTION
Hello, I propose to create a new branch for this bundle for versions of symfony 2.8 or higher.

I propose to create migration files in the var / directory instead of app / (currently in this bundle).
So we can give permissions to the var / folder.
regards