### PR TITLE
Allow to use migration diff when using only DBAL

### DIFF
--- a/Command/MigrationsDiffDoctrineCommand.php
+++ b/Command/MigrationsDiffDoctrineCommand.php
@@ -14,10 +14,7 @@
 
 namespace Doctrine\Bundle\MigrationsBundle\Command;
 
-use Doctrine\Bundle\DoctrineBundle\Command\Proxy\DoctrineCommandHelper;
 use Doctrine\DBAL\Migrations\Tools\Console\Command\DiffCommand;
-use Doctrine\DBAL\Sharding\PoolingShardConnection;
-use LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -37,6 +34,7 @@ class MigrationsDiffDoctrineCommand extends DiffCommand
 
         $this
             ->setName('doctrine:migrations:diff')
+            ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.')
         ;
@@ -44,16 +42,7 @@ class MigrationsDiffDoctrineCommand extends DiffCommand
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        DoctrineCommandHelper::setApplicationEntityManager($this->getApplication(), $input->getOption('em'));
-
-        if ($input->getOption('shard')) {
-            $connection = $this->getApplication()->getHelperSet()->get('db')->getConnection();
-            if (!$connection instanceof PoolingShardConnection) {
-                throw new LogicException(sprintf("Connection of EntityManager '%s' must implements shards configuration.", $input->getOption('em')));
-            }
-
-            $connection->connect($input->getOption('shard'));
-        }
+        Helper\DoctrineCommandHelper::setApplicationHelper($this->getApplication(), $input);
 
         $configuration = $this->getMigrationConfiguration($input, $output);
         DoctrineCommand::configureMigrations($this->getApplication()->getKernel()->getContainer(), $configuration);


### PR DESCRIPTION
Right now migration:diff command is only working with ORM. Some developers even use ORM only to make it possible to sync database schema, even if they don't need or don't use ORM features.

Another use case is that there is a need to use both dbal and orm for different parts of applications. So for example some part of the schema is not defined by ORM metadata. In that case developer could implement chained schema provider (or just decorate OrmSchemaProvider) to add additional schema definition. `doctrine/migration` (see issue #226) package provides a way to specify custom schema provider which then could be used to compare schemas. 

This PR provides changes to allow usage of this command using just DBAL. It also reduce code duplication for handling sharding.

The open questions is how to pass correct schema provider implementation into `MigrationsDiffDoctrineCommand` constructor, but this could be done in another PR. Right now I just registering this command as service and pass needed service as dependency. But maybe there might be a better way.
