### PR TITLE
Ability to change the class template

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -67,6 +67,10 @@ abstract class DoctrineCommand extends BaseCommand
             $configuration->registerMigrationsFromDirectory($configuration->getMigrationsDirectory());
         }
 
+        if (!$configuration->getCustomTemplate()) {
+            $configuration->setCustomTemplate($container->getParameter('doctrine_migrations.custom_template'));
+        }
+
         $organizeMigrations = $container->getParameter('doctrine_migrations.organize_migrations');
         switch ($organizeMigrations) {
             case Configuration::VERSIONS_ORGANIZATION_BY_YEAR:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -42,6 +42,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
+                ->scalarNode('custom_template')->defaultValue(null)->end()
                 ->scalarNode('organize_migrations')->defaultValue(false)
                     ->info('Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false')
                     ->validate()


### PR DESCRIPTION
Related to this issue : https://github.com/doctrine/DoctrineMigrationsBundle/issues/199

Related to PR : https://github.com/doctrine/migrations/pull/535

Here's the PR that introduce custom template for command doctrine:migrations:generate.

```yml
# app/config/config.yml
doctrine_migrations:
    dir_name: "%kernel.root_dir%/DoctrineMigrations"
    namespace: Application\Migrations
    table_name: migration_versions
    name: Application Migrations
    custom_template: src/MyBundle/Resources/tpl/migration.tpl
```

It also add a command option in order to set custom template just for the current command.

E.G: bin/console do:mi:ge --template src/MyBundle/Resources/tpl/migration.tpl