### PR TITLE
Update index.rst. Missing "organize_migrations" in documentation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -48,7 +48,7 @@ following:
 Configuration
 -------------
 
-You can configure the path, namespace, table_name and name in your ``config.yml``. The examples below are the default values.
+You can configure the path, namespace, table_name, name and organize_migrations in your ``config.yml``. The examples below are the default values.
 
 .. code-block:: yaml
 
@@ -58,6 +58,7 @@ You can configure the path, namespace, table_name and name in your ``config.yml`
         namespace: Application\Migrations
         table_name: migration_versions
         name: Application Migrations
+        organize_migrations: false # Version >=1.2 Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false
 
 Usage
 -----


### PR DESCRIPTION
Related to this issue: #202.

Missing "organize_migrations" option than has been added in #153.
This is information help to know about different settings structure of folder.