### PR TITLE
Add command registration to fix Symfony 3.4 auto-registration deprecation

### DIFF
--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -14,7 +14,9 @@
 
 namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 
+use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -39,6 +41,11 @@ class DoctrineMigrationsExtension extends Extension
         foreach ($config as $key => $value) {
             $container->setParameter($this->getAlias().'.'.$key, $value);
         }
+
+        $locator = new FileLocator(__DIR__ . '/../Resources/config/');
+        $loader  = new XmlFileLoader($container, $locator);
+
+        $loader->load('services.xml');
     }
 
     /**

--- a/DoctrineMigrationsBundle.php
+++ b/DoctrineMigrationsBundle.php
@@ -14,6 +14,7 @@
 
 namespace Doctrine\Bundle\MigrationsBundle;
 
+use Symfony\Component\Console\Application;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="doctrine_migrations.diff_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsDiffDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.execute_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsExecuteDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.generate_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsGenerateDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.latest_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsLatestDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.migrate_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsMigrateDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.status_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsStatusDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+        <service id="doctrine_migrations.version_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsVersionDoctrineCommand">
+            <tag name="console.command" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
Commands auto-registration is deprecated in Symfony 3.4. This PR will avoid Auto-registration of the command "Doctrine\Bundle\DoctrineCacheBundle\Command\xxx" is deprecated since Symfony 3.4 and won't be supported in 4.0. Use PSR-4 based service discovery instead. exceptions.