### PR TITLE
Drop symfony 2.3 support, allow 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.7|~3.3|~4.0",
         "doctrine/doctrine-bundle": "~1.0",
         "doctrine/migrations": "^1.1"
     },


### PR DESCRIPTION
2.3 is not maintained anymore, 4.0 beta1 is out.