### PR TITLE
Add method_exists to avoid fatal error

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -67,7 +67,7 @@ abstract class DoctrineCommand extends BaseCommand
             $configuration->registerMigrationsFromDirectory($configuration->getMigrationsDirectory());
         }
 
-        if (!$configuration->getCustomTemplate()) {
+        if (method_exists($configuration, 'getCustomTemplate') && !$configuration->getCustomTemplate()) {
             $configuration->setCustomTemplate($container->getParameter('doctrine_migrations.custom_template'));
         }
 

--- a/Tests/Command/DoctrineCommandTest.php
+++ b/Tests/Command/DoctrineCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection;
+
+use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
+use Doctrine\DBAL\Migrations\Configuration\Configuration;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+
+class DoctrineCommandTest extends \PHPUnit\Framework\TestCase
+{
+    public function testConfigureMigrations()
+    {
+        $configurationMock = $this->getMockBuilder('Doctrine\DBAL\Migrations\Configuration\Configuration')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $configurationMock->method('getMigrations')
+            ->willReturn(array());
+
+        DoctrineCommand::configureMigrations($this->getContainer(), $configurationMock);
+    }
+
+    private function getContainer()
+    {
+        return new ContainerBuilder(new ParameterBag(array(
+            'doctrine_migrations.dir_name' => __DIR__.'/../../',
+            'doctrine_migrations.namespace' => 'test',
+            'doctrine_migrations.name' => 'test',
+            'doctrine_migrations.table_name' => 'test',
+            'doctrine_migrations.organize_migrations' => Configuration::VERSIONS_ORGANIZATION_BY_YEAR,
+        )));
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/migrations": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^4.8.36"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "" }


### PR DESCRIPTION
Related error:
```
  [Symfony\Component\Debug\Exception\UndefinedMethodException]
  Attempted to call an undefined method named "getCustomTemplate" of class "Doctrine\DBAL\Migrations\Configuration\Configuration".
```

This commit can be reverted when https://github.com/doctrine/migrations v1.6 is released.

Relates to https://github.com/doctrine/DoctrineMigrationsBundle/issues/207
Relates to https://github.com/doctrine/DoctrineMigrationsBundle/compare/v1.2.1...v1.3.0#commitcomment-24024900