### PR TITLE
Unstable Custom Template Breaking

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -55,11 +55,7 @@ abstract class DoctrineCommand extends BaseCommand
         if (!($configuration instanceof AbstractFileConfiguration)) {
             $configuration->registerMigrationsFromDirectory($configuration->getMigrationsDirectory());
         }
-
-        if (!$configuration->getCustomTemplate()) {
-            $configuration->setCustomTemplate($container->getParameter('doctrine_migrations.custom_template'));
-        }
-
+        
         $organizeMigrations = $container->getParameter('doctrine_migrations.organize_migrations');
         switch ($organizeMigrations) {
             case Configuration::VERSIONS_ORGANIZATION_BY_YEAR:

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,7 +31,6 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('namespace')->defaultValue('Application\Migrations')->cannotBeEmpty()->end()
                 ->scalarNode('table_name')->defaultValue('migration_versions')->cannotBeEmpty()->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
-                ->scalarNode('custom_template')->defaultValue(null)->end()
                 ->scalarNode('organize_migrations')->defaultValue(false)
                     ->info('Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false')
                     ->validate()


### PR DESCRIPTION
The custom template configuration is used in version 1.3.0 of this bundle; however, this is not in the current stable release of doctrine/migrations. Should be removed from the 1.3 line until it is stable in the required doctrine/migrations version.