### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Command/DoctrineCommandTest.php
+++ b/Tests/Command/DoctrineCommandTest.php
@@ -30,6 +30,7 @@ class DoctrineCommandTest extends TestCase
             'doctrine_migrations.name' => 'test',
             'doctrine_migrations.table_name' => 'test',
             'doctrine_migrations.organize_migrations' => Configuration::VERSIONS_ORGANIZATION_BY_YEAR,
+            'doctrine_migrations.custom_template' => null,
         )));
     }
 }

--- a/Tests/Command/DoctrineCommandTest.php
+++ b/Tests/Command/DoctrineCommandTest.php
@@ -6,8 +6,9 @@ use Doctrine\Bundle\MigrationsBundle\Command\DoctrineCommand;
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineCommandTest extends \PHPUnit\Framework\TestCase
+class DoctrineCommandTest extends TestCase
 {
     public function testConfigureMigrations()
     {

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -6,8 +6,9 @@ use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExten
 use Doctrine\DBAL\Migrations\Configuration\Configuration;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use PHPUnit\Framework\TestCase;
 
-class DoctrineMigrationsExtensionTest extends \PHPUnit_Framework_TestCase
+class DoctrineMigrationsExtensionTest extends TestCase
 {
     public function testOrganizeMigrations()
     {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/migrations": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8.36"
+        "phpunit/phpunit": "^4.8.36|^5.7|^6.4"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "" }


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).