### PR TITLE
Require versions below doctrine/migrations 1.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": ">=5.4.0",
         "symfony/framework-bundle": "~2.7|~3.3|~4.0",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/migrations": "^1.1"
+        "doctrine/migrations": "~1.2.0|~1.5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36"


### PR DESCRIPTION
This fixes #219 discovered in #218.

Require versions below `doctrine/migrations` [`1.6`](https://github.com/doctrine/migrations/releases/tag/v1.6.0) that [has some methods with `PHP 7` return type declaration](https://github.com/doctrine/migrations/pull/545).

I just need to require versions below `1.2`, because of [version `1.3` required `PHP 5.5`](https://github.com/doctrine/migrations/releases/tag/v1.3.0), and we have tests with `PHP 5.4`.