### PR TITLE
Move phpstan and doctrine/coding-standards to require-dev instead of require.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,15 @@
     "require": {
         "php": "^7.1",
         "symfony/framework-bundle": "~3.4|~4.0",
-        "doctrine/coding-standard": "^4.0",
         "doctrine/doctrine-bundle": "~1.0",
-        "doctrine/migrations": "^2.0@dev",
-        "phpstan/phpstan": "^0.9.2",
-        "phpstan/phpstan-strict-rules": "^0.9"
+        "doctrine/migrations": "^2.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7|^6.4|^7.0",
-        "mikey179/vfsStream": "^1.6"
+        "mikey179/vfsStream": "^1.6",
+        "doctrine/coding-standard": "^4.0",
+        "phpstan/phpstan": "^0.9.2",
+        "phpstan/phpstan-strict-rules": "^0.9"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "" }


### PR DESCRIPTION
Noticed that phpstan and coding-standards were in require while I'm guessing these are only necessary in require-dev. 