### PR TITLE
fix indentation in config tree builder

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -64,8 +64,8 @@ class Configuration implements ConfigurationInterface
                             ->then(static function ($v) {
                                 return constant('Doctrine\Migrations\Configuration\Configuration::VERSIONS_ORGANIZATION_' . strtoupper($v));
                             })
-                        ->end()
                     ->end()
+                ->end()
             ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
first `->end()` belongs to `->validate()`'s `ExprBuilder`, and the second one is now inline with it's `ScalarNodeDefinition` creator `->scalarNode('organize_migrations')->defaultValue(false)`