### PR TITLE
fixed doctrine version for `custom_template`

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -52,7 +52,7 @@ application:
         name: 'Application Migrations'
         # available in version >= 1.2. Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false
         organize_migrations: false
-        # available in version >= 1.2. Path to your custom migrations template
+        # available in version >= 1.3. Path to your custom migrations template
         custom_template: ~
         all_or_nothing: false
 


### PR DESCRIPTION
parameter `custom_template` is only available since version `1.3` as you can see v `1.2.1` doesn't include this yet: https://github.com/doctrine/DoctrineMigrationsBundle/blob/v1.2.1/DependencyInjection/Configuration.php