### PR TITLE
Add schema provider setting

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -73,6 +73,7 @@ class Configuration implements ConfigurationInterface
                             })
                     ->end()
                 ->end()
+                ->scalarNode('schema_provider')->defaultValue(null)->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 /**
@@ -33,6 +34,8 @@ class DoctrineMigrationsExtension extends Extension
         $loader  = new XmlFileLoader($container, $locator);
 
         $loader->load('services.xml');
+
+        $this->configureSchemaProvider($config, $container);
     }
 
     /**
@@ -48,5 +51,18 @@ class DoctrineMigrationsExtension extends Extension
     public function getNamespace() : string
     {
         return 'http://symfony.com/schema/dic/doctrine/migrations';
+    }
+
+    /**
+     * @param string[][] $configs
+     */
+    private function configureSchemaProvider(array $config, ContainerBuilder $container) : void
+    {
+        if (! $config['schema_provider']) {
+            return;
+        }
+
+        $diffCommand = $container->findDefinition('doctrine_migrations.diff_command');
+        $diffCommand->setArgument(0, new Reference($config['schema_provider']));
     }
 }

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -54,7 +54,7 @@ class DoctrineMigrationsExtension extends Extension
     }
 
     /**
-     * @param string[][] $configs
+     * @param string[] $config
      */
     private function configureSchemaProvider(array $config, ContainerBuilder $container) : void
     {

--- a/Resources/config/schema/doctrine_migrations-1.0.xsd
+++ b/Resources/config/schema/doctrine_migrations-1.0.xsd
@@ -24,6 +24,7 @@
                     </xsd:restriction>
                 </xsd:simpleType>
             </xsd:attribute>
+            <xsd:attribute name="schema-provider" type="xsd:string" />
         </xsd:complexType>
     </xsd:element>
 </xsd:schema>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -6,6 +6,7 @@
 
     <services>
         <service id="doctrine_migrations.diff_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsDiffDoctrineCommand">
+            <argument />
             <tag name="console.command" />
         </service>
         <service id="doctrine_migrations.dump_schema_command" class="Doctrine\Bundle\MigrationsBundle\Command\MigrationsDumpSchemaDoctrineCommand">

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -55,6 +55,7 @@ application:
         # available in version >= 1.3. Path to your custom migrations template
         custom_template: ~
         all_or_nothing: false
+        schema_provider: ~
 
 Usage
 -----

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -6,9 +6,12 @@ namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection;
 
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
 use Doctrine\Migrations\Configuration\Configuration;
+use Doctrine\Migrations\Provider\StubSchemaProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
+use Symfony\Component\DependencyInjection\Reference;
 use function sys_get_temp_dir;
 
 class DoctrineMigrationsExtensionTest extends TestCase
@@ -25,6 +28,25 @@ class DoctrineMigrationsExtensionTest extends TestCase
         $this->assertEquals(
             Configuration::VERSIONS_ORGANIZATION_BY_YEAR,
             $container->getParameter('doctrine_migrations.organize_migrations')
+        );
+    }
+
+    public function testSchemaProvider() : void
+    {
+        $container = $this->getContainer();
+        $container->set('app.schema_provider', new Definition(StubSchemaProvider::class));
+
+        $extension = new DoctrineMigrationsExtension();
+
+        $config = ['schema_provider' => 'app.schema_provider'];
+
+        $extension->load(['doctrine_migrations' => $config], $container);
+
+        $diffCommand = $container->findDefinition('doctrine_migrations.diff_command');
+
+        $this->assertEquals(
+            new Reference('app.schema_provider'),
+            $diffCommand->getArgument(0)
         );
     }
 


### PR DESCRIPTION
As mentioned in #190 there's no setting for the diff command's schema provider. This adds a `schema_provider` setting.

Refs https://github.com/libero/content-store/pull/8#discussion_r279656101.