### PR TITLE
Minor improvements in the docs

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -15,11 +15,11 @@ Installation
 
 Run this command in your terminal:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ composer require doctrine/doctrine-migrations-bundle "^2.0"
 
-If you don't use Symfony Flex, you must enable the bundle manually in the application:
+If you don't use `Symfony Flex`_, you must enable the bundle manually in the application:
 
 .. code-block:: php
 
@@ -61,7 +61,7 @@ Usage
 
 All of the migrations functionality is contained in a few console commands:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     doctrine
      doctrine:migrations:diff                [diff] Generate a migration by comparing your current database to your mapping information.
@@ -78,7 +78,7 @@ All of the migrations functionality is contained in a few console commands:
 Start by getting the status of migrations in your application by running
 the ``status`` command:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:status
 
@@ -106,7 +106,7 @@ Now, you can start working with migrations by generating a new blank migration
 class. Later, you'll learn how Doctrine can generate migrations automatically
 for you.
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:generate
     Generated new migration class to "/path/to/project/app/Migrations/Version20180605025653.php"
@@ -153,7 +153,7 @@ like the following:
 If you run the ``status`` command it will now show that you have one new
 migration to execute:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:status --show-versions
 
@@ -184,7 +184,7 @@ migration to execute:
 Now you can add some migration code to the ``up()`` and ``down()`` methods and
 finally migrate when you're ready:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:migrate 20180605025653
 
@@ -193,6 +193,7 @@ fill in the ``up()`` and ``down()`` methods), see the official Doctrine Migratio
 `documentation`_.
 
 .. tip::
+
     If you need to use another database connection to execute migrations you may use option ``--db="doctrine-connection-name"`` 
     where ``doctrine-connection-name`` is valid Doctrine connection defined in doctrine.yaml
 
@@ -219,7 +220,7 @@ Skipping Migrations
 
 You can skip single migrations by explicitly adding them to the ``migration_versions`` table:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:version YYYYMMDDHHMMSS --add
 
@@ -301,7 +302,7 @@ With this information, Doctrine is now ready to help you persist your new
 doesn't exist yet! Generate a new migration for this table automatically by
 running the following command:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:diff
 
@@ -310,7 +311,7 @@ the schema differences. If you open this file, you'll find that it has the
 SQL code needed to create the ``user`` table. Next, run the migration
 to add the table to your database:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:migrate
 
@@ -327,7 +328,7 @@ for your project.
 If you don't want to use this workflow and instead create your schema via
 ``doctrine:schema:create``, you can tell Doctrine to skip all existing migrations:
 
-.. code-block:: bash
+.. code-block:: terminal
 
     $ php bin/console doctrine:migrations:version --add --all
 
@@ -338,7 +339,7 @@ Manual Tables
 
 It is a common use case, that in addition to your generated database structure
 based on your doctrine entities you might need custom tables. By default such
-tables will be removed by the doctrine:migrations:diff command.
+tables will be removed by the ``doctrine:migrations:diff`` command.
 
 If you follow a specific scheme you can configure doctrine/dbal to ignore those
 tables. Let's say all custom tables will be prefixed by ``t_``. In this case you
@@ -375,3 +376,4 @@ will need to be placed per-connection.
 .. _documentation: https://www.doctrine-project.org/projects/doctrine-migrations/en/current/index.html
 .. _DoctrineMigrationsBundle: https://github.com/doctrine/DoctrineMigrationsBundle
 .. _`Doctrine Database Migrations`: https://github.com/doctrine/migrations
+.. _`Symfony Flex`: https://symfony.com/doc/current/setup/flex.html


### PR DESCRIPTION
These are very minor and aesthetic-only changes. At symfony.com, `bash` code blocks are only used for Bash-style examples (e.g. the contents of `.env` files). For terminal/console examples, we recommend to use the `terminal` code block to display the fake terminal window around it. Thanks.