### PR TITLE
Support check_database_platform option

### DIFF
--- a/Command/DoctrineCommand.php
+++ b/Command/DoctrineCommand.php
@@ -85,6 +85,7 @@ abstract class DoctrineCommand extends BaseCommand
         $configuration->setMigrationsColumnLength($container->getParameter('doctrine_migrations.column_length'));
         $configuration->setMigrationsExecutedAtColumnName($container->getParameter('doctrine_migrations.executed_at_column_name'));
         $configuration->setAllOrNothing($container->getParameter('doctrine_migrations.all_or_nothing'));
+        $configuration->setCheckDatabasePlatform($container->getParameter('doctrine_migrations.check_database_platform'));
 
         // Migrations is not register from configuration loader
         if (! ($configuration instanceof AbstractFileConfiguration)) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,6 +50,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('all_or_nothing')->defaultValue(false)->end()
                 ->scalarNode('name')->defaultValue('Application Migrations')->end()
                 ->scalarNode('custom_template')->defaultValue(null)->end()
+                ->scalarNode('check_database_platform')->defaultValue(true)->end()
                 ->scalarNode('organize_migrations')->defaultValue(false)
                     ->info('Organize migrations mode. Possible values are: "BY_YEAR", "BY_YEAR_AND_MONTH", false')
                     ->validate()

--- a/Resources/config/schema/doctrine_migrations-1.0.xsd
+++ b/Resources/config/schema/doctrine_migrations-1.0.xsd
@@ -15,6 +15,7 @@
             <xsd:attribute name="all_or_nothing" type="xsd:boolean" />
             <xsd:attribute name="name" type="xsd:string" />
             <xsd:attribute name="custom_template" type="xsd:string" />
+            <xsd:attribute name="check_database_platform" type="xsd:boolean" />
             <xsd:attribute name="organize-migrations">
                 <xsd:simpleType>
                     <xsd:restriction base="xsd:string">

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -53,6 +53,7 @@ application:
         # available in version >= 1.3. Path to your custom migrations template
         custom_template: ~
         all_or_nothing: false
+        check_database_platform: true
 
 Usage
 -----

--- a/Tests/Command/DoctrineCommandTest.php
+++ b/Tests/Command/DoctrineCommandTest.php
@@ -72,6 +72,10 @@ class DoctrineCommandTest extends TestCase
             ->method('setAllOrNothing')
             ->with(false);
 
+        $configurationMock->expects($this->once())
+            ->method('setCheckDatabasePlatform')
+            ->with(true);
+
         DoctrineCommand::configureMigrations($this->getContainer(), $configurationMock);
     }
 
@@ -88,6 +92,7 @@ class DoctrineCommandTest extends TestCase
             'doctrine_migrations.organize_migrations' => Configuration::VERSIONS_ORGANIZATION_BY_YEAR,
             'doctrine_migrations.custom_template' => null,
             'doctrine_migrations.all_or_nothing' => false,
+            'doctrine_migrations.check_database_platform' => true,
         ]));
     }
 }


### PR DESCRIPTION
Since doctrine/migrations 2.1.0 (https://github.com/doctrine/migrations/pull/784) version there are new option `check_database_platform`.

I added support for this option.

My questions:
1) Should I specify in doc comment about `available since version`?
2) PR should be to master, or 2.0 branch? **master**
3) Should I update composer dependencies, or increase minimal `doctrine/migrations` version to `^2.1` to avoid `method_exists` check? **Yes**