### PR TITLE
Lazy console commands

### DIFF
--- a/Command/MigrationsDiffDoctrineCommand.php
+++ b/Command/MigrationsDiffDoctrineCommand.php
@@ -19,12 +19,14 @@ use function assert;
  */
 class MigrationsDiffDoctrineCommand extends DiffCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:diff';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:diff')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_OPTIONAL, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsDumpSchemaDoctrineCommand.php
+++ b/Command/MigrationsDumpSchemaDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsDumpSchemaDoctrineCommand extends DumpSchemaCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:dump-schema';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:dump-schema')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsExecuteDoctrineCommand.php
+++ b/Command/MigrationsExecuteDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsExecuteDoctrineCommand extends ExecuteCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:execute';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:execute')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsGenerateDoctrineCommand.php
+++ b/Command/MigrationsGenerateDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsGenerateDoctrineCommand extends GenerateCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:generate';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:generate')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsLatestDoctrineCommand.php
+++ b/Command/MigrationsLatestDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsLatestDoctrineCommand extends LatestCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:latest';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:latest')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsMigrateDoctrineCommand.php
+++ b/Command/MigrationsMigrateDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsMigrateDoctrineCommand extends MigrateCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:migrate';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:migrate')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsRollupDoctrineCommand.php
+++ b/Command/MigrationsRollupDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsRollupDoctrineCommand extends RollupCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:rollup';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:rollup')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsStatusDoctrineCommand.php
+++ b/Command/MigrationsStatusDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsStatusDoctrineCommand extends StatusCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:status';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:status')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsUpToDateDoctrineCommand.php
+++ b/Command/MigrationsUpToDateDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsUpToDateDoctrineCommand extends UpToDateCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:up-to-date';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:up-to-date')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/Command/MigrationsVersionDoctrineCommand.php
+++ b/Command/MigrationsVersionDoctrineCommand.php
@@ -18,12 +18,14 @@ use function assert;
  */
 class MigrationsVersionDoctrineCommand extends VersionCommand
 {
+    /** @var string */
+    protected static $defaultName = 'doctrine:migrations:version';
+
     protected function configure() : void
     {
         parent::configure();
 
         $this
-            ->setName('doctrine:migrations:version')
             ->addOption('db', null, InputOption::VALUE_REQUIRED, 'The database connection to use for this command.')
             ->addOption('em', null, InputOption::VALUE_REQUIRED, 'The entity manager to use for this command.')
             ->addOption('shard', null, InputOption::VALUE_REQUIRED, 'The shard connection to use for this command.');

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.1",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
         "doctrine/doctrine-bundle": "~1.0|~2.0",
-        "doctrine/migrations": "^2.0"
+        "doctrine/migrations": "^2.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.4|^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4467af166b27206571f084879d46deea",
+    "content-hash": "4f8309374987e325778be2f7d244c78f",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -694,16 +694,16 @@
         },
         {
             "name": "doctrine/migrations",
-            "version": "2.1.2",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/migrations.git",
-                "reference": "d4e050a8c956d275255d8fc281b28e0c91b7fe0e"
+                "reference": "8e124252d2f6be1124017d746d5994dd4095d66f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/migrations/zipball/d4e050a8c956d275255d8fc281b28e0c91b7fe0e",
-                "reference": "d4e050a8c956d275255d8fc281b28e0c91b7fe0e",
+                "url": "https://api.github.com/repos/doctrine/migrations/zipball/8e124252d2f6be1124017d746d5994dd4095d66f",
+                "reference": "8e124252d2f6be1124017d746d5994dd4095d66f",
                 "shasum": ""
             },
             "require": {
@@ -711,8 +711,8 @@
                 "ocramius/package-versions": "^1.3",
                 "ocramius/proxy-manager": "^2.0.2",
                 "php": "^7.1",
-                "symfony/console": "^3.4||^4.0",
-                "symfony/stopwatch": "^3.4||^4.0"
+                "symfony/console": "^3.4||^4.0||^5.0",
+                "symfony/stopwatch": "^3.4||^4.0||^5.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
@@ -725,8 +725,8 @@
                 "phpstan/phpstan-phpunit": "^0.10",
                 "phpstan/phpstan-strict-rules": "^0.10",
                 "phpunit/phpunit": "^7.0",
-                "symfony/process": "^3.4||^4.0",
-                "symfony/yaml": "^3.4||^4.0"
+                "symfony/process": "^3.4||^4.0||^5.0",
+                "symfony/yaml": "^3.4||^4.0||^5.0"
             },
             "suggest": {
                 "jdorn/sql-formatter": "Allows to generate formatted SQL with the diff command.",
@@ -738,7 +738,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
@@ -772,7 +772,7 @@
                 "migrations",
                 "php"
             ],
-            "time": "2019-09-30T09:46:55+00:00"
+            "time": "2019-11-13T11:06:31+00:00"
         },
         {
             "name": "doctrine/persistence",


### PR DESCRIPTION
|      Q       |   A
|------------- | -----------
| Type         | improvement
| BC Break     | no

Since Symfony `3.4` console commands can be lazy thanks to [a static name property](https://github.com/symfony/symfony/pull/23887).
This change does not break BC because the BC layer is already [in the base command's constructor](https://github.com/symfony/symfony/pull/23887/files#diff-8e80595663798837db1b033187835535R75).
