### PR TITLE
Fix of branch names for doctrine website build

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -1,18 +1,49 @@
 {
-    "name": "Doctrine Migrations Bundle",
-    "shortName": "DoctrineMigrationsBundle",
-    "slug": "doctrine-migrations-bundle",
-    "versions": [
-        {
-            "name": "2.0",
-            "branchName": "2.0",
-            "slug": "2.0",
-            "current": true
-        },
-        {
-            "name": "1.3",
-            "branchName": "1.3",
-            "slug": "1.3"
-        }
-    ]
+  "name": "Doctrine Migrations Bundle",
+  "shortName": "DoctrineMigrationsBundle",
+  "slug": "doctrine-migrations-bundle",
+  "versions": [
+    {
+      "name": "2.2",
+      "branchName": "master",
+      "slug": "2.2",
+      "upcoming": true
+    },
+    {
+      "name": "2.1",
+      "branchName": "2.1.x",
+      "slug": "2.1",
+      "current": true
+    },
+    {
+      "name": "2.0",
+      "branchName": "2.0.x",
+      "slug": "2.0",
+      "maintained": false
+    },
+    {
+      "name": "1.3",
+      "branchName": "1.3",
+      "slug": "1.3",
+      "maintained": false
+    },
+    {
+      "name": "1.2",
+      "branchName": "1.2",
+      "slug": "1.2",
+      "maintained": false
+    },
+    {
+      "name": "1.1",
+      "branchName": "1.1",
+      "slug": "1.1",
+      "maintained": false
+    },
+    {
+      "name": "1.0",
+      "branchName": "1.0",
+      "slug": "1.0",
+      "maintained": false
+    }
+  ]
 }


### PR DESCRIPTION
This should fix the collections version infos and the build error error: pathspec 'origin/2.0' did not match any file(s) known to git on Doctrine website build.

@alcaeus Can you please take a look if the version states are correct in .doctrine-project.json?