### PR TITLE
Detect the entity manager in a compiler pass

### DIFF
--- a/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
+++ b/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass;
+
+use Doctrine\Migrations\DependencyFactory;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use function sprintf;
+
+class ConfigureDependencyFactoryPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container) : void
+    {
+        $preferredEm  = $container->getParameter('doctrine.migrations.preferred_em');
+        $diDefinition = $container->getDefinition('doctrine.migrations.dependency_factory');
+
+        $emID = sprintf('doctrine.orm.%s_entity_manager', $preferredEm ?: 'default');
+
+        if ($container->has($emID)) {
+            $container->getDefinition('doctrine.migrations.em_loader')
+                ->setArgument(0, new Reference($emID));
+
+            $diDefinition->setFactory([DependencyFactory::class, 'fromEntityManager']);
+            $diDefinition->setArgument(1, new Reference('doctrine.migrations.em_loader'));
+        } else {
+            $preferredConnection = $container->getParameter('doctrine.migrations.preferred_connection');
+            $connectionId        = sprintf('doctrine.dbal.%s_connection', $preferredConnection ?: 'default');
+            $container->getDefinition('doctrine.migrations.connection_loader')
+                ->setArgument(0, new Reference($connectionId));
+
+            $diDefinition->setFactory([DependencyFactory::class, 'fromConnection']);
+            $diDefinition->setArgument(1, new Reference('doctrine.migrations.connection_loader'));
+        }
+    }
+}

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 
-use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use InvalidArgumentException;
@@ -14,7 +13,6 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
-use function sprintf;
 
 /**
  * DoctrineMigrationsExtension.
@@ -98,22 +96,8 @@ class DoctrineMigrationsExtension extends Extension
             );
         }
 
-        $emID = sprintf('doctrine.orm.%s_entity_manager', $config['em'] ?: 'default');
-
-        if ($container->has($emID)) {
-            $container->getDefinition('doctrine.migrations.em_loader')
-                ->setArgument(0, new Reference($emID));
-
-            $diDefinition->setFactory([DependencyFactory::class, 'fromEntityManager']);
-            $diDefinition->setArgument(1, new Reference('doctrine.migrations.em_loader'));
-        } else {
-            $connectionId = sprintf('doctrine.dbal.%s_connection', $config['connection'] ?? 'default');
-            $container->getDefinition('doctrine.migrations.connection_loader')
-                ->setArgument(0, new Reference($connectionId));
-
-            $diDefinition->setFactory([DependencyFactory::class, 'fromConnection']);
-            $diDefinition->setArgument(1, new Reference('doctrine.migrations.connection_loader'));
-        }
+        $container->setParameter('doctrine.migrations.preferred_em', $config['em']);
+        $container->setParameter('doctrine.migrations.preferred_connection', $config['connection']);
     }
 
     /**

--- a/DoctrineMigrationsBundle.php
+++ b/DoctrineMigrationsBundle.php
@@ -3,6 +3,8 @@
 
 namespace Doctrine\Bundle\MigrationsBundle;
 
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\ConfigureDependencyFactoryPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -13,4 +15,8 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class DoctrineMigrationsBundle extends Bundle
 {
+    public function build(ContainerBuilder $builder)
+    {
+      $builder->addCompilerPass(new ConfigureDependencyFactoryPass());
+    }
 }

--- a/Tests/DependencyInjection/DoctrineCommandsTest.php
+++ b/Tests/DependencyInjection/DoctrineCommandsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection;
 
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\ConfigureDependencyFactoryPass;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand;
@@ -104,6 +105,7 @@ class DoctrineCommandsTest extends TestCase
             ],
         ], $container);
 
+        $container->addCompilerPass(new ConfigureDependencyFactoryPass());
         $container->compile();
 
         return $application;


### PR DESCRIPTION
Fixes https://github.com/doctrine/DoctrineMigrationsBundle/issues/297

This PR moves in a compiler pass the detection of the entity manager or dbal connection.