### PR TITLE
Remove unknown 2.2.x branch from config

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -10,12 +10,6 @@
       "upcoming": true
     },
     {
-      "name": "2.2",
-      "branchName": "2.2.x",
-      "slug": "2.2",
-      "upcoming": true
-    },
-    {
       "name": "2.1",
       "branchName": "2.1.x",
       "slug": "2.1",


### PR DESCRIPTION
The website build is breaking because it cannot fetch the branch 2.2.x from this repository. Either we delete the branch from the config, which is the content of this PR, or we create this missing branch for this repository.