### PR TITLE
Update default table name

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -64,7 +64,7 @@ application:
         storage:
             # Default (SQL table) metadata storage configuration
             table_storage:
-                table_name: 'migration_versions'
+                table_name: 'doctrine_migration_versions'
                 version_column_name: 'version'
                 version_column_length: 1024
                 executed_at_column_name: 'executed_at'


### PR DESCRIPTION
The default name seems to be `doctrine_migration_versions`:

https://github.com/doctrine/migrations/blob/master/lib/Doctrine/Migrations/Metadata/Storage/TableMetadataStorageConfiguration.php#L10