### PR TITLE
Drop application name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,8 +46,6 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('migration', 'migrations')
             ->fixXmlConfig('migrations_path', 'migrations_paths')
             ->children()
-                ->scalarNode('name')->defaultValue('Application Migrations')->end()
-
                 ->arrayNode('migrations_paths')
                     ->info('A list of namespace/path pairs where to look for migrations.')
                     ->isRequired()

--- a/Tests/Fixtures/conf.xml
+++ b/Tests/Fixtures/conf.xml
@@ -8,7 +8,6 @@
 
 
     <doctrine:config
-            name="Doctrine Sandbox Migrations"
             all_or_nothing="true"
             check_database_platform="true"
             organize-migrations="BY_YEAR_AND_MONTH"


### PR DESCRIPTION
Because the minimum migrations version doesn't contain the application name
anymore, it is also removed from the bundle config. (See https://github.com/doctrine/DoctrineMigrationsBundle/pull/306#issuecomment-606851129)