### PR TITLE
Allow bundle-relative paths in the migration path resolution

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -47,6 +47,7 @@ application:
         migrations_paths:
             'App\Migrations': 'src/App'
             'AnotherApp\Migrations': '/path/to/other/migrations'
+            'SomeBundle\Migrations': '@SomeBundle/Migrations'
 
         # List of additional migration classes to be loaded, optional
         migrations:

--- a/Tests/Fixtures/TestBundle/TestBundle.php
+++ b/Tests/Fixtures/TestBundle/TestBundle.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\TestBundle;
+
+use Symfony\Component\HttpKernel\Bundle\Bundle;
+
+class TestBundle extends Bundle
+{
+}


### PR DESCRIPTION
this allows to specify bundle relative paths for migrations.

closes https://github.com/doctrine/DoctrineMigrationsBundle/issues/312