### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,16 +4,22 @@
   "slug": "doctrine-migrations-bundle",
   "versions": [
     {
-      "name": "3.0",
+      "name": "3.1",
       "branchName": "master",
-      "slug": "3.0",
+      "slug": "3.1",
       "upcoming": true
+    },
+    {
+      "name": "3.0",
+      "branchName": "3.0.x",
+      "slug": "3.0",
+      "current": true
     },
     {
       "name": "2.1",
       "branchName": "2.1.x",
       "slug": "2.1",
-      "current": true
+      "maintained": false
     },
     {
       "name": "2.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "extra": {
         "branch-alias": {
-          "dev-master": "3.0.x-dev"
+          "dev-master": "3.1.x-dev"
         }
     }
 }


### PR DESCRIPTION
- mark 2.1.x as unmaintained;
- mark 3.0.x as current;
- alias master to 3.1.

Not 100% sure that we stop maintenance on 2.1.x, or that master is 3.1 and not 4.0 (not sure when major branches are supposed to be created).