### PR TITLE
Document table name BC break

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -40,7 +40,7 @@ doctrine_migrations:
         table_storage:
             table_name: 'migration_versions'
             version_column_name: 'version'
-            version_column_length: 1024
+            version_column_length: 191
             executed_at_column_name: 'executed_at'
 ```
 - The migration name has been dropped:
@@ -55,6 +55,17 @@ doctrine_migrations:
 After
 
 The parameter `name` has been dropped.
+
+
+- The default for `table_name` changed from `migration_versions` to `doctrine_migration_versions`. If you did not
+specify the `table_name` option, you now need to declare it explicitly to not lose migration data.
+
+```yaml
+doctrine_migrations:
+    storage:
+        table_storage:
+            table_name: 'migration_versions'
+```
 
 - Custom migration templates:
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -67,16 +67,8 @@ doctrine_migrations:
             table_name: 'migration_versions'
 ```
 
-- Custom migration templates:
+### Underlying doctrine/migrations library
 
-Before
-
-```php
-final class Version<version> extends AbstractMigration
-```
-
-After
-
-```php
-final class <className> extends AbstractMigration
-```
+Upgrading this bundle to `3.0` will also update the `doctrine/migrations` library to the version `3.0`.
+Backward incompatible changes in `doctrine/migrations` 3.0 
+are documented in the dedicated [UPGRADE](https://github.com/doctrine/migrations/blob/3.0.x/UPGRADE.md) document. 


### PR DESCRIPTION
In `doctrine/migrations` 3.x and `doctrine/DoctrineMigrationsBundle` 3.x the default value for  `table name` is `doctrine_migration_versions`.

In the previous 2.x versions the doctrine/migrations library was using as default `doctrine_migration_versions` while the bundle was using `migration_versions`.

Closes https://github.com/doctrine/migrations/issues/1002
