### PR TITLE
Resolve `symfony/config:5.1` deprecation with `setDeprecated` method

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -44,7 +44,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('name')
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated.'))
                     ->defaultValue('Application Migrations')
                 ->end()
 
@@ -92,27 +92,27 @@ class Configuration implements ConfigurationInterface
 
                 ->scalarNode('dir_name')
                     ->defaultValue('%kernel.root_dir%/DoctrineMigrations')->cannotBeEmpty()
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
                 ->end()
                 ->scalarNode('namespace')
                     ->defaultValue('Application\Migrations')->cannotBeEmpty()
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
                 ->end()
                 ->scalarNode('table_name')
                     ->defaultValue('migration_versions')->cannotBeEmpty()
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.table_name" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "storage.table_storage.table_name" instead.'))
                 ->end()
                 ->scalarNode('column_name')
                     ->defaultValue('version')
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.version_column_name" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "storage.table_storage.version_column_name" instead.'))
                 ->end()
                 ->scalarNode('column_length')
                     ->defaultValue(14)
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.version_column_length" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "storage.table_storage.version_column_length" instead.'))
                 ->end()
                 ->scalarNode('executed_at_column_name')
                     ->defaultValue('executed_at')
-                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.executed_at_column_name" instead.'))
+                    ->setDeprecated(...$this->getDeprecationParams('The "%node%" option is deprecated. Use "storage.table_storage.executed_at_column_name" instead.'))
                 ->end()
                 ->scalarNode('all_or_nothing')->defaultValue(false)->end()
                 ->scalarNode('custom_template')->defaultValue(null)->end()
@@ -179,7 +179,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return string[]
      */
-    private function getParamDeprecationMsg(string $message) : array
+    private function getDeprecationParams(string $message) : array
     {
         if (method_exists(BaseNode::class, 'getDeprecation')) {
             return [

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 
 use ReflectionClass;
+use Symfony\Component\Config\Definition\BaseNode;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use function constant;
@@ -43,7 +44,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->scalarNode('name')
-                    ->setDeprecated('The "%node%" option is deprecated.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated.'))
                     ->defaultValue('Application Migrations')
                 ->end()
 
@@ -91,27 +92,27 @@ class Configuration implements ConfigurationInterface
 
                 ->scalarNode('dir_name')
                     ->defaultValue('%kernel.root_dir%/DoctrineMigrations')->cannotBeEmpty()
-                    ->setDeprecated('The "%node%" option is deprecated. Use "migrations_paths" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
                 ->end()
                 ->scalarNode('namespace')
                     ->defaultValue('Application\Migrations')->cannotBeEmpty()
-                    ->setDeprecated('The "%node%" option is deprecated. Use "migrations_paths" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "migrations_paths" instead.'))
                 ->end()
                 ->scalarNode('table_name')
                     ->defaultValue('migration_versions')->cannotBeEmpty()
-                    ->setDeprecated('The "%node%" option is deprecated. Use "storage.table_storage.table_name" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.table_name" instead.'))
                 ->end()
                 ->scalarNode('column_name')
                     ->defaultValue('version')
-                    ->setDeprecated('The "%node%" option is deprecated. Use "storage.table_storage.version_column_name" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.version_column_name" instead.'))
                 ->end()
                 ->scalarNode('column_length')
                     ->defaultValue(14)
-                    ->setDeprecated('The "%node%" option is deprecated. Use "storage.table_storage.version_column_length" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.version_column_length" instead.'))
                 ->end()
                 ->scalarNode('executed_at_column_name')
                     ->defaultValue('executed_at')
-                    ->setDeprecated('The "%node%" option is deprecated. Use "storage.table_storage.executed_at_column_name" instead.')
+                    ->setDeprecated(...$this->getParamDeprecationMsg('The "%node%" option is deprecated. Use "storage.table_storage.executed_at_column_name" instead.'))
                 ->end()
                 ->scalarNode('all_or_nothing')->defaultValue(false)->end()
                 ->scalarNode('custom_template')->defaultValue(null)->end()
@@ -166,5 +167,28 @@ class Configuration implements ConfigurationInterface
         }
 
         return $namesArray;
+    }
+
+    /**
+     * Returns the correct deprecation param's as an array for setDeprecated.
+     *
+     * Symfony/Config v5.1 introduces a deprecation notice when calling
+     * setDeprecation() with less than 3 args and the getDeprecation method was
+     * introduced at the same time. By checking if getDeprecation() exists,
+     * we can determine the correct param count to use when calling setDeprecated.
+     *
+     * @return string[]
+     */
+    private function getParamDeprecationMsg(string $message) : array
+    {
+        if (method_exists(BaseNode::class, 'getDeprecation')) {
+            return [
+                'doctrine/doctrine-migrations-bundle',
+                '2.2',
+                $message,
+            ];
+        }
+
+        return [$message];
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -170,12 +170,12 @@ class Configuration implements ConfigurationInterface
     }
 
     /**
-     * Returns the correct deprecation param's as an array for setDeprecated.
+     * Returns the correct deprecation params as an array for setDeprecated().
      *
-     * Symfony/Config v5.1 introduces a deprecation notice when calling
-     * setDeprecation() with less than 3 args and the getDeprecation method was
+     * symfony/config v5.1 introduces a deprecation notice when calling
+     * setDeprecated() with less than 3 args and the getDeprecation() method was
      * introduced at the same time. By checking if getDeprecation() exists,
-     * we can determine the correct param count to use when calling setDeprecated.
+     * we can determine the correct param count to use when calling setDeprecated().
      *
      * @return string[]
      */


### PR DESCRIPTION
inspired by https://github.com/doctrine/DoctrineBundle/commit/ca38c08c0b950733eb50587e4a1fda181e63b10d

#356