### PR TITLE
Upgrade instructions for projects without an existing metadata table definition.

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -43,6 +43,15 @@ doctrine_migrations:
             version_column_length: 191
             executed_at_column_name: 'executed_at'
 ```
+If your project did not originally specify its own table definition configuration, you will need to configure the table name after the upgrade:
+
+```yaml
+doctrine_migrations:
+    storage:
+        table_storage:
+            table_name: 'migration_versions'
+```
+and then run the `doctrine:migrations:sync-metadata-storage` command.
 - The migration name has been dropped:
 
 Before


### PR DESCRIPTION
I spent some time figuring out why I couldn't get the upgrade to work, until I realized that the metadata table instructions seemed as if they weren't applicable if projects didn't originally override this configuration in the first place. This PR aims to introduce the minimal instructions needed to upgrade such projects.

Running the `doctrine:migrations:sync-metadata-storage` command results in the `execution_time` column being added with `NULL` values. I presume that's alright as it's done by default and running migrations appears to work successfully afterwards, but please do verify that.