### PR TITLE
php 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
         "doctrine/doctrine-bundle": "~1.0|~2.0",
         "doctrine/migrations": "^2.2"


### PR DESCRIPTION
doctrine/doctrine-migrations-bundle 2.1.2 requires php ^7.1 -> your PHP version (8.0.0) does not satisfy that requirement.
