### PR TITLE
Fix YAML extensions of config files

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -242,12 +242,12 @@ Here is an example on how to inject the service container into your migrations:
 
     .. code-block:: yaml
 
-        # config/packages/doctrine_migrations.yml
+        # config/packages/doctrine_migrations.yaml
         doctrine_migrations:
             services:
                  'Doctrine\Migrations\Version\MigrationFactory': 'App\Migrations\Factory\MigrationFactoryDecorator'
 
-        # config/services.yml
+        # config/services.yaml
         services:
             Doctrine\Migrations\Version\DbalMigrationFactory: ~
             App\Migrations\Factory\MigrationFactoryDecorator:
@@ -330,7 +330,7 @@ for Doctrine's ORM:
 
     .. code-block:: yaml
 
-        # config/doctrine/User.orm.yml
+        # config/doctrine/User.orm.yaml
         App\Entity\User:
             type: entity
             table: user


### PR DESCRIPTION
[Since Symfony 4](http://fabien.potencier.org/symfony4-directory-structure.html#configuration-under-config), YAML config files have the `.yaml` extension in Symfony.

Although this bundle is also compatible with Symfony 3.x, I guess it may be useful to use the most up-to-date extension in the doc.

Thanks for the great work!