### PR TITLE
Fix usage of the "connection" configuration

### DIFF
--- a/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
+++ b/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
@@ -15,20 +15,20 @@ class ConfigureDependencyFactoryPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void
     {
-        $preferredEm  = $container->getParameter('doctrine.migrations.preferred_em');
-        $diDefinition = $container->getDefinition('doctrine.migrations.dependency_factory');
+        $preferredEm         = $container->getParameter('doctrine.migrations.preferred_em');
+        $preferredConnection = $container->getParameter('doctrine.migrations.preferred_connection');
+        $diDefinition        = $container->getDefinition('doctrine.migrations.dependency_factory');
 
         $emID = sprintf('doctrine.orm.%s_entity_manager', $preferredEm ?? 'default');
 
-        if ($container->has($emID)) {
+        if ($preferredConnection === null && $container->has($emID)) {
             $container->getDefinition('doctrine.migrations.em_loader')
                 ->setArgument(0, new Reference($emID));
 
             $diDefinition->setFactory([DependencyFactory::class, 'fromEntityManager']);
             $diDefinition->setArgument(1, new Reference('doctrine.migrations.em_loader'));
         } else {
-            $preferredConnection = $container->getParameter('doctrine.migrations.preferred_connection');
-            $connectionId        = sprintf('doctrine.dbal.%s_connection', $preferredConnection ?? 'default');
+            $connectionId = sprintf('doctrine.dbal.%s_connection', $preferredConnection ?? 'default');
             $container->getDefinition('doctrine.migrations.connection_loader')
                 ->setArgument(0, new Reference($connectionId));
 

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -260,6 +260,29 @@ class DoctrineMigrationsExtensionTest extends TestCase
         self::assertSame($conn, $di->getConnection());
     }
 
+    public function testCustomConnectionWhenDefaultEntityManagerExists(): void
+    {
+        $config    = [
+            'migrations_paths' => ['DoctrineMigrationsTest' => 'a'],
+            'connection' => 'custom',
+        ];
+        $container = $this->getContainer($config);
+
+        $conn = $this->createMock(Connection::class);
+        $container->set('doctrine.dbal.custom_connection', $conn);
+
+        $em     = $this->createMock(EntityManager::class);
+        $emConn = $this->createMock(Connection::class);
+        $em->method('getConnection')->willReturn($emConn);
+        $container->set('doctrine.orm.default_entity_manager', $em);
+
+        $container->compile();
+
+        $di = $container->get('doctrine.migrations.dependency_factory');
+        self::assertInstanceOf(DependencyFactory::class, $di);
+        self::assertSame($conn, $di->getConnection());
+    }
+
     public function testPrefersEntityManagerOverConnection(): void
     {
         $config    = [


### PR DESCRIPTION
Setting an other database configuration then the "default" was not possible when you use the default entity manager. This change will check if the connection configuration is set before checking the entity manager. Because "connection" and "em" are mutually exclusive this wouldn't be a problem.

This could be a fix for #360, but I use SF5.2 for this.