### PR TITLE
[3.0] Add support for PHP 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -30,6 +30,8 @@ jobs:
         include:
           - deps: "low"
             php-version: "7.2"
+          - deps: "dev"
+            php-version: "8.0"
 
     steps:
       - name: "Checkout"
@@ -51,14 +53,13 @@ jobs:
           key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
-      # to be removed when doctrine/orm adds support for PHP 8
-      - name: "Pretend this is PHP 7.4"
-        run: "composer config platform.php 7.4.99"
-        if: "${{ matrix.php-version == '8.0' }}"
+      - name: "Allow installing dev dependencies"
+        run: "composer config minimum-stability dev"
+        if: "${{ matrix.deps == 'dev' }}"
 
       - name: "Install dependencies with composer"
         run: "composer update --no-interaction --prefer-dist"
-        if: "${{ matrix.deps == 'normal' }}"
+        if: "${{ matrix.deps != 'low' }}"
 
       - name: "Install lowest possible dependencies with composer"
         run: "composer update --no-interaction --prefer-dist --prefer-lowest"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
         "doctrine/doctrine-bundle": "~1.0|~2.0",
         "doctrine/migrations": "~3.0"
@@ -42,11 +42,6 @@
     },
     "autoload-dev": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\Tests\\": "Tests" }
-    },
-    "config": {
-        "platform": {
-            "php": "7.2.5"
-        }
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
With doctrine/migrations 3.0.x-dev supporting PHP (see https://github.com/doctrine/migrations/pull/1101), we can add support for PHP 8 in 3.0 here as well. PHP 8 support for 2.x is a different issue, as it requires significant work in the base library to make that compatible with PHP 8. At this time, we can't guarantee whether 2.x will be made to work on PHP 8 as well.