### PR TITLE
documentation, incorrect migrations_paths example missing %kernel.project_dir%

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -45,7 +45,7 @@ application:
     doctrine_migrations:
         # List of namespace/path pairs to search for migrations, at least one required
         migrations_paths:
-            'App\Migrations': 'src/App'
+            'App\Migrations': '%kernel.project_dir%/src/Migrations'
             'AnotherApp\Migrations': '/path/to/other/migrations'
             'SomeBundle\Migrations': '@SomeBundle/Migrations'
 
@@ -135,6 +135,12 @@ already executed, which still need to run, and the database in use.
 Now, you can start working with migrations by generating a new blank migration
 class. Later, you'll learn how Doctrine can generate migrations automatically
 for you.
+
+.. code-block:: terminal
+
+    $ php bin/console make:migration
+    
+or by using doctrine migrations directly
 
 .. code-block:: terminal
 

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -138,8 +138,6 @@ for you.
 
 .. code-block:: terminal
 
-.. code-block:: terminal
-
     $ php bin/console doctrine:migrations:generate
 
 Have a look at the newly generated migration class and you will see something

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -138,10 +138,6 @@ for you.
 
 .. code-block:: terminal
 
-    $ php bin/console make:migration
-    
-or by using doctrine migrations directly
-
 .. code-block:: terminal
 
     $ php bin/console doctrine:migrations:generate


### PR DESCRIPTION
not correct config given in documentation:
```
doctrine_migrations:
  migrations_paths:
     'App\Migrations': 'src/App'
```

replaced to:
`'App\Migrations': '%kernel.project_dir%/src/Migrations'`

current is not correct and will give error: `Migrations directory "src/App" does not exist. ` tested in symfony 4.4 LTS

also added info about using `php bin/console make:migration` instead of `php bin/console doctrine:migrations:generate`