### PR TITLE
Update index.rst adding project_dir to the first migration_path example

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -45,10 +45,9 @@ application:
     doctrine_migrations:
         # List of namespace/path pairs to search for migrations, at least one required
         migrations_paths:
-            'App\Migrations': 'src/App'
+            'App\Migrations': '%kernel.project_dir%/src/App'
             'AnotherApp\Migrations': '/path/to/other/migrations'
             'SomeBundle\Migrations': '@SomeBundle/Migrations'
-            'OtherApp\Migrations': '%kernel.project_dir%/src/OtherApp/Migrations'
 
         # List of additional migration classes to be loaded, optional
         migrations:

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -48,6 +48,7 @@ application:
             'App\Migrations': 'src/App'
             'AnotherApp\Migrations': '/path/to/other/migrations'
             'SomeBundle\Migrations': '@SomeBundle/Migrations'
+            'OtherApp\Migrations': '%kernel.project_dir%/src/OtherApp/Migrations'
 
         # List of additional migration classes to be loaded, optional
         migrations:


### PR DESCRIPTION
An example using `%kernel.project_dir%` is useful because it doesn't break if you run console from a location other than the project root.