### PR TITLE
Debug toolbar breaks when executed migrations list is empty

### DIFF
--- a/Resources/views/Collector/migrations.html.twig
+++ b/Resources/views/Collector/migrations.html.twig
@@ -19,7 +19,7 @@
         {% set text %}
             <div class="sf-toolbar-info-piece">
                 <b>Current</b>
-                <span>{{ collector.data.executed_migrations|last.version|split('\\')|last }}</span>
+                <span>{{ executed_migrations > 0 ? collector.data.executed_migrations|last.version|split('\\')|last : 'n/a' }}</span>
             </div>
             <div class="sf-toolbar-info-piece">
                 <b>Executed</b>


### PR DESCRIPTION
If there are no previously executed migrations the `last` function returns `false` which breaks the toolbar.

![image](https://user-images.githubusercontent.com/2445045/114253197-7b2cfa00-99a9-11eb-8171-2a406d7474b3.png)
