### PR TITLE
Merge 3.0.x up into 3.1.x

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,0 +1,4 @@
+branches: ["2.2.x", "3.0.x", "3.1.x"]
+maintained_branches: ["2.2.x", "3.0.x", "3.1.x"]
+doc_dir: "Resources/doc/"
+dev_branch: "3.1.x"


### PR DESCRIPTION
I'm hoping this will make 3.1.x the default on Symfony.com cc @yyaremenko