### PR TITLE
Reduced value of version_column_length to avoid "Specified key was too long" error (migration_versions)

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -65,7 +65,7 @@ application:
             table_storage:
                 table_name: 'doctrine_migration_versions'
                 version_column_name: 'version'
-                version_column_length: 1024
+                version_column_length: 192
                 executed_at_column_name: 'executed_at'
 
         # Possible values: "BY_YEAR", "BY_YEAR_AND_MONTH", false


### PR DESCRIPTION
When running with `version_column_length` at `1024` I received errors like:

> An exception occurred while executing 'ALTER TABLE migration_versions CHANGE version version VARCHAR(1024) NOT NULL':  
> SQLSTATE[42000]: Syntax error or access violation: 1071 Specified key was too long; max key length is 3072 bytes

Changing it to a lower value solved this problem.

Ref: https://github.com/doctrine/migrations/issues/958