### PR TITLE
[Doc] Fix minor RST syntax issue

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -91,11 +91,9 @@ application:
             # Custom migration sorting service id via callables (MyCallableFactory must be a callable)
             'Doctrine\Migrations\Version\Comparator': 'MyCallableFactory'
 
-
-
-
 - The ``services`` node allows you to provide custom services to the underlying ``DependencyFactory`` part of ``doctrine/migrations``.
 - The node ``factories`` is similar to ``services``, with the difference that it accepts only callables.
+
 The provided callable must return the service to be passed to the ``DependencyFactory``.
 The callable will receive as first argument the ``DependencyFactory`` itself,
 allowing you to fetch other dependencies from the factory while instantiating your custom dependencies.


### PR DESCRIPTION
Current docs show this error:

```
Warning in "index" around line 99: List ends without a blank line; unexpected unindent.
```

The real fix is adding a blank line after the list of items.