### PR TITLE
Allow configuring "transactional" config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -151,6 +151,10 @@ class Configuration implements ConfigurationInterface
                     ->info('Use profiler to calculate and visualize migration status.')
                     ->defaultFalse()
                 ->end()
+                ->booleanNode('transactional')
+                    ->info('Whether or not to wrap migrations in a single transaction.')
+                    ->defaultTrue()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -77,6 +77,8 @@ class DoctrineMigrationsExtension extends Extension
             $this->registerCollector($container);
         }
 
+        $configurationDefinition->addMethodCall('setTransactional', [$config['transactional']]);
+
         $diDefinition = $container->getDefinition('doctrine.migrations.dependency_factory');
 
         if (! isset($config['services'][MigrationFactory::class])) {

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -80,6 +80,9 @@ application:
         # Adds an extra check in the generated migrations to ensure that is executed on the same database type.
         check_database_platform: true
 
+        # Whether or not to wrap migrations in a single transaction.
+        transactional: true
+
         services:
             # Custom migration sorting service id
             'Doctrine\Migrations\Version\Comparator': ~

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -395,6 +395,36 @@ class DoctrineMigrationsExtensionTest extends TestCase
         $container->compile();
     }
 
+    public function testTransactionalIsTrueIfNotSet(): void
+    {
+        $container = $this->getContainerBuilder();
+
+        $container->registerExtension(new DoctrineMigrationsExtension());
+        $container->setAlias('doctrine.migrations.configuration.test', new Alias('doctrine.migrations.configuration', true));
+
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Fixtures'));
+        $loader->load('conf.xml');
+
+        $container->compile();
+
+        $config = $container->get('doctrine.migrations.configuration.test');
+        assert($config instanceof Configuration);
+
+        self::assertTrue($config->isTransactional());
+    }
+
+    public function testTransactionalSetToFalseReflectsInConfig(): void
+    {
+        $config    = ['transactional' => false];
+        $container = $this->getContainer($config);
+        $container->compile();
+
+        $config = $container->get('doctrine.migrations.configuration');
+        assert($config instanceof Configuration);
+
+        self::assertFalse($config->isTransactional());
+    }
+
     /**
      * @param mixed[]      $config
      * @param mixed[]|null $dbalConfig

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "php": "^7.2|^8.0",
         "symfony/framework-bundle": "~3.4|~4.0|~5.0",
         "doctrine/doctrine-bundle": "~1.0|~2.0",
-        "doctrine/migrations": "^3.1"
+        "doctrine/migrations": "^3.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0|^8.0|^9.0",


### PR DESCRIPTION
Since doctrine/migrations 3.2 a new "transactional" config key is available: https://github.com/doctrine/migrations/pull/1157

This PR aims to make it configurable using the bundle.

I targeted the "3.1.x" branch as 3.2.x is not available yet.