### PR TITLE
Remove duplicate collector calls

### DIFF
--- a/Collector/MigrationsCollector.php
+++ b/Collector/MigrationsCollector.php
@@ -25,6 +25,10 @@ class MigrationsCollector extends DataCollector
 
     public function collect(Request $request, Response $response, \Throwable $exception = null)
     {
+        if (!empty($this->data)) {
+            return;
+        }
+
         $metadataStorage = $this->dependencyFactory->getMetadataStorage();
         $planCalculator = $this->dependencyFactory->getMigrationPlanCalculator();
 


### PR DESCRIPTION
When a sub-request is done (eg: with `controller` Twig function), the collector is called twice.

This PR will avoid additional database queries in this case.