### PR TITLE
add type declaration to suspend the deprecated info message

### DIFF
--- a/Collector/MigrationsCollector.php
+++ b/Collector/MigrationsCollector.php
@@ -58,6 +58,9 @@ class MigrationsCollector extends DataCollector
         $this->data['namespaces'] = $configuration->getMigrationDirectories();
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'doctrine_migrations';


### PR DESCRIPTION
Added the explicit @return to suspend the deprecation info msg as showed in the following:

```
➜ dcphp bin/console c:c
Xdebug: [Step Debug] Could not connect to debugging client. Tried: host.docker.internal:9003 (through xdebug.client_host/xdebug.client_port) :-(

 // Clearing the cache for the dev environment with debug true

 [OK] Cache for the "dev" environment (debug=true) was successfully cleared.

2021-10-03T20:24:45+02:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::getName()" might add "string" as a native return type declaration in the future. Do the same in implementation "Doctrine\Bundle\MigrationsBundle\Collector\MigrationsCollector" now to avoid errors or add an explicit @return annotation to suppress this message.
```