### PR TITLE
Added support for `Configuration#setTransactional()` configuration in `doctrine/doctrine-migrations-bundle`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -119,6 +119,20 @@ class Configuration implements ConfigurationInterface
                     ->info('Run all migrations in a transaction.')
                     ->defaultValue(false)
                 ->end()
+                ->booleanNode('transactional')
+                    ->info(<<<'INFO'
+By default, individual migrations run in a DB transaction: this flag allows disabling transaction support.
+
+When dealing with databases that switch to auto-commit mode after DDL, such as MySQL, it is sometimes
+preferable to not run migrations within a transaction, since:
+
+ * the migration cannot be rolled back via a DB transaction rollback anyway
+ * the migration will be in a dirty state, and requires manual recovery anyway
+ * a transaction error will only obscure the underlying issue in your migration
+INFO
+                    )
+                    ->defaultValue(true)
+                ->end()
                 ->scalarNode('check_database_platform')
                     ->info('Adds an extra check in the generated migrations to allow execution only on the same platform as they were initially generated on.')
                     ->defaultValue(true)

--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -70,6 +70,7 @@ class DoctrineMigrationsExtension extends Extension
             $configurationDefinition->addMethodCall('setCustomTemplate', [$config['custom_template']]);
         }
 
+        $configurationDefinition->addMethodCall('setTransactional', [$config['transactional']]);
         $configurationDefinition->addMethodCall('setAllOrNothing', [$config['all_or_nothing']]);
         $configurationDefinition->addMethodCall('setCheckDatabasePlatform', [$config['check_database_platform']]);
 

--- a/Resources/config/schema/doctrine_migrations-3.0.xsd
+++ b/Resources/config/schema/doctrine_migrations-3.0.xsd
@@ -54,6 +54,18 @@
             <xsd:attribute name="em" type="xsd:string"/>
             <xsd:attribute name="connection" type="xsd:string"/>
             <xsd:attribute name="sorter" type="xsd:string"/>
+
+            <!--
+            By default, individual migrations run in a DB transaction: this flag allows disabling transaction support.
+
+            When dealing with databases that switch to auto-commit mode after DDL, such as MySQL, it is sometimes
+            preferable to not run migrations within a transaction, since:
+
+             * the migration cannot be rolled back via a DB transaction rollback anyway
+             * the migration will be in a dirty state, and requires manual recovery anyway
+             * a transaction error will only obscure the underlying issue in your migration
+            -->
+            <xsd:attribute name="transactional" default="true" type="xsd:boolean"/>
             <xsd:attribute name="all_or_nothing" type="xsd:boolean"/>
             <xsd:attribute name="check_database_platform" type="xsd:boolean"/>
             <xsd:attribute name="custom_template" type="xsd:string"/>

--- a/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/Tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -76,6 +76,7 @@ class DoctrineMigrationsExtensionTest extends TestCase
 
             'organize_migrations' => 'BY_YEAR_AND_MONTH',
 
+            'transactional'             => true,
             'all_or_nothing'            => true,
             'check_database_platform'   => true,
         ];
@@ -86,6 +87,18 @@ class DoctrineMigrationsExtensionTest extends TestCase
         $config = $container->get('doctrine.migrations.configuration');
 
         $this->assertConfigs($config);
+    }
+
+    public function testAllowsDisablingTransactionalSupportForIndividualMigrations(): void
+    {
+        $container = $this->getContainer(['transactional' => false]);
+
+        $container->compile();
+
+        $config = $container->get('doctrine.migrations.configuration');
+
+        self::assertInstanceOf(Configuration::class, $config);
+        self::assertFalse($config->isTransactional());
     }
 
     public function testNoConfigsAreNeeded(): void

--- a/Tests/Fixtures/conf.xml
+++ b/Tests/Fixtures/conf.xml
@@ -2,16 +2,16 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xmlns:doctrine="http://symfony.com/schema/dic/doctrine/migrations/3.0"
            xsi:schemaLocation="
-           http://symfony.com/schema/dic/doctrine/migrations/3.0 http://symfony.com/schema/dic/doctrine/migrations/doctrine_migrations-3.0.xsd
-           http://symfony.com/schema/dic/services https://symfony.com/schema/dic/services/services-1.0.xsd
+           http://symfony.com/schema/dic/doctrine/migrations/3.0 ../../Resources/config/schema/doctrine_migrations-3.0.xsd
+           http://symfony.com/schema/dic/services ../../vendor/symfony/dependency-injection/Loader/schema/dic/services/services-1.0.xsd
 ">
 
 
     <doctrine:config
+            transactional="true"
             all_or_nothing="true"
             check_database_platform="true"
             organize-migrations="BY_YEAR_AND_MONTH"
-
     >
 
         <doctrine:migrations-path namespace="DoctrineMigrationsTest">a</doctrine:migrations-path>


### PR DESCRIPTION
This patch introduces a way to set `Configuration#setTransactional()` via DIC parameters, introduced
in https://github.com/doctrine/migrations/pull/1157, but never implemented at configuration level.

Ref: https://github.com/doctrine/migrations/pull/1157
Ref: https://github.com/doctrine/migrations/issues/1153

@greg0ire note: I've set the milestone to `3.2.0`, but beware that the current default branch is `3.1.x` - unsure why