### PR TITLE
Require PHPUnit >= 8

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,6 @@ on:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.2.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.2.1"
     with:
       php-versions: '["7.2", "7.3", "7.4", "8.0"]'

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "doctrine/migrations": "^3.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0|^8.0|^9.0",
+        "phpunit/phpunit": "^8.0|^9.0",
         "doctrine/coding-standard": "^8.0",
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-deprecation-rules": "^0.12",


### PR DESCRIPTION
We have dropped PHP 7.1, which means we can drop PHPUnit 7, which will
in turn result in the prefer-lowest job being able to generate a
coverage file, instead of warning that "No coverage driver is
available".