### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,16 +4,32 @@
   "slug": "doctrine-migrations-bundle",
   "versions": [
     {
+      "name": "3.3",
+      "branchName": "3.3.x",
+      "slug": "latest",
+      "upcoming": true
+    },
+    {
+      "name": "3.2",
+      "branchName": "3.2.x",
+      "slug": "3.2",
+      "aliases": [
+        "current",
+        "stable"
+      ],
+      "current": true
+    },
+    {
       "name": "3.1",
       "branchName": "3.1.x",
       "slug": "3.1",
-      "upcoming": true
+      "maintained": false
     },
     {
       "name": "3.0",
       "branchName": "3.0.x",
       "slug": "3.0",
-      "current": true
+      "maintained": false
     },
     {
       "name": "2.2",

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,4 +1,4 @@
-branches: ["2.2.x", "3.0.x", "3.1.x"]
-maintained_branches: ["2.2.x", "3.0.x", "3.1.x"]
+branches: ["2.2.x", "3.0.x", "3.1.x", "3.2.x", "3.3.x"]
+maintained_branches: ["2.2.x", "3.2.x", "3.3.x"]
 doc_dir: "Resources/doc/"
-dev_branch: "3.1.x"
+dev_branch: "3.3.x"


### PR DESCRIPTION
3.2.0 has been released three weeks ago. That would make 3.2.x our currently maintained branch. I have updated the metadata accordingly.