### PR TITLE
fix toolbar and menu not showing in profiler

### DIFF
--- a/Resources/views/Collector/migrations.html.twig
+++ b/Resources/views/Collector/migrations.html.twig
@@ -3,7 +3,7 @@
 {% import _self as helper %}
 
 {% block toolbar %}
-    {% if collector.data.unavailable_migrations is defined %}
+    {% if collector.data.unavailable_migrations_count is defined %}
         {% set unavailable_migrations = collector.data.unavailable_migrations_count %}
         {% set new_migrations = collector.data.new_migrations|length %}
         {% if unavailable_migrations > 0 or new_migrations > 0 %}
@@ -47,7 +47,7 @@
 
 
 {% block menu %}
-    {% if collector.data.unavailable_migrations is defined %}
+    {% if collector.data.unavailable_migrations_count is defined %}
         {% set unavailable_migrations = collector.data.unavailable_migrations_count %}
         {% set new_migrations = collector.data.new_migrations|length %}
         {% set label = unavailable_migrations > 0 ? 'label-status-warning' : '' %}


### PR DESCRIPTION
With these issues #423 and #421

there was a merge issue that produce an effect to not showing the menu in profiler because the `$this->data['unavailable_migrations']` is no longer available in `Collector/MigrationsCollector.php` and was replaced by `$this->data['unavailable_migrations_count']`