### PR TITLE
Document profiler overhead

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -148,7 +148,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->booleanNode('enable_profiler')
-                    ->info('Use profiler to calculate and visualize migration status.')
+                    ->info('Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead.')
                     ->defaultFalse()
                 ->end()
                 ->booleanNode('transactional')

--- a/README.markdown
+++ b/README.markdown
@@ -1,7 +1,7 @@
 DoctrineMigrationsBundle
 ========================
 
-This bundle integrates the [Doctrine2 Migrations library](http://www.doctrine-project.org/projects/migrations.html)
+This bundle integrates the [Doctrine Migrations library](http://www.doctrine-project.org/projects/migrations.html)
 into Symfony applications. Database migrations help you version the changes in
 your database schema and apply them in a predictable way on every server running
 the application.

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -83,6 +83,9 @@ application:
         # Whether or not to wrap migrations in a single transaction.
         transactional: true
 
+        # Whether or not to enable the profiler collector. This add some queries overhead.
+        # enable_profiler: false
+
         services:
             # Custom migration sorting service id
             'Doctrine\Migrations\Version\Comparator': ~

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -83,7 +83,7 @@ application:
         # Whether or not to wrap migrations in a single transaction.
         transactional: true
 
-        # Whether or not to enable the profiler collector. This add some queries overhead.
+        # Use profiler to calculate and visualize migration status.
         # enable_profiler: false
 
         services:

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -83,7 +83,7 @@ application:
         # Whether or not to wrap migrations in a single transaction.
         transactional: true
 
-        # Use profiler to calculate and visualize migration status.
+        # Whether or not to enable the profiler collector to calculate and visualize migration status. This adds some queries overhead.
         # enable_profiler: false
 
         services:


### PR DESCRIPTION
After upgrading the bundle recipe on a local app
I saw the new profiler icon and also some queries overhead (~10queries)

Ref https://github.com/symfony/recipes/blob/9a7f5bcebbda2f5244c4be4133a6bd181080cbea/doctrine/doctrine-migrations-bundle/3.1/config/packages/doctrine_migrations.yaml#L6