### PR TITLE
hide deprecation warning

### DIFF
--- a/DoctrineMigrationsBundle.php
+++ b/DoctrineMigrationsBundle.php
@@ -14,7 +14,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class DoctrineMigrationsBundle extends Bundle
 {
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
       $container->addCompilerPass(new ConfigureDependencyFactoryPass());
     }


### PR DESCRIPTION
with symfony 6.1 I got such warning:

```
2023-03-28T12:23:12+02:00 [info] User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```

such change repair it