### PR TITLE
Added `return void` annotation to suppress deprecation warnings in Bundle::build()

### DIFF
--- a/DoctrineMigrationsBundle.php
+++ b/DoctrineMigrationsBundle.php
@@ -14,6 +14,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class DoctrineMigrationsBundle extends Bundle
 {
+    /** @return void */
     public function build(ContainerBuilder $container)
     {
       $container->addCompilerPass(new ConfigureDependencyFactoryPass());


### PR DESCRIPTION
When version 3.2.2 of this bundle is used together with Symfony 6.3 (Symfony 6.3.0-BETA1), the following warning is logged:
```
Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle" now to avoid errors or add an explicit @return annotation to suppress this message.
```