### PR TITLE
Deprecate ContainerAwareMigrationFactory

### DIFF
--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -13,6 +13,7 @@ use InvalidArgumentException;
 use RuntimeException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
@@ -23,6 +24,7 @@ use function array_keys;
 use function assert;
 use function explode;
 use function implode;
+use function interface_exists;
 use function is_array;
 use function sprintf;
 use function strlen;
@@ -130,6 +132,12 @@ class DoctrineMigrationsExtension extends Extension
 
         $container->setParameter('doctrine.migrations.preferred_em', $config['em']);
         $container->setParameter('doctrine.migrations.preferred_connection', $config['connection']);
+
+        if (interface_exists(ContainerAwareInterface::class)) {
+            return;
+        }
+
+        $container->removeDefinition('doctrine.migrations.container_aware_migrations_factory');
     }
 
     private function checkIfBundleRelativePath(string $path, ContainerBuilder $container): string

--- a/MigrationsFactory/ContainerAwareMigrationFactory.php
+++ b/MigrationsFactory/ContainerAwareMigrationFactory.php
@@ -9,6 +9,9 @@ use Doctrine\Migrations\Version\MigrationFactory;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
+/**
+ * @deprecated This class is not compatible with Symfony >= 7
+ */
 class ContainerAwareMigrationFactory implements MigrationFactory
 {
     /**
@@ -32,6 +35,8 @@ class ContainerAwareMigrationFactory implements MigrationFactory
         $migration = $this->migrationFactory->createVersion($migrationClassName);
 
         if ($migration instanceof ContainerAwareInterface) {
+            trigger_deprecation('doctrine/doctrine-migrations-bundle', '3.3', 'Migration "%s" implements "%s" to gain access to the application\'s service container. This method is deprecated and won\'t work with Symfony 7.', $migrationClassName, ContainerAwareInterface::class);
+
             $migration->setContainer($this->container);
         }
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     ],
     "require": {
         "php": "^7.2|^8.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "doctrine/doctrine-bundle": "^2.4",
         "doctrine/migrations": "^3.2"
@@ -37,6 +38,8 @@
         "doctrine/persistence": "^2.0 || ^3 ",
         "psalm/plugin-phpunit": "^0.18.4",
         "psalm/plugin-symfony": "^3 || ^5",
+        "symfony/phpunit-bridge": "^6.3 || ^7",
+        "symfony/var-exporter": "^5.4 || ^6 || ^7",
         "vimeo/psalm": "^4.30 || ^5.15"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,8 @@
             </exclude>
         </whitelist>
     </filter>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,7 +3,7 @@
     errorLevel="4"
     phpVersion="8.2"
     findUnusedBaselineEntry="true"
-    findUnusedCode="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"


### PR DESCRIPTION
`ContainerAwareInterface` will be removed in Symfony 7 which renders `ContainerAwareMigrationFactory` useless. I'm therefore deprecating this feature.

I realize that we don't have a replacement (yet), but since we already know that we can't keep this feature, we might as well deprecate it now. Someone who uses that feature might want to step forward and build a replacement.