### PR TITLE
Removed deprecated option --show-versions in documentation

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -183,7 +183,7 @@ migration to execute:
 
 .. code-block:: terminal
 
-    $ php bin/console doctrine:migrations:status --show-versions
+    $ php bin/console doctrine:migrations:status
 
 Now you can add some migration code to the ``up()`` and ``down()`` methods and
 finally migrate when you're ready:


### PR DESCRIPTION
The option --show-versions is removed in PR https://github.com/doctrine/migrations/pull/956. Using the option will result in an error shown in the console.

![Scherm­afbeelding 2023-12-15 om 16 32 02](https://github.com/doctrine/DoctrineMigrationsBundle/assets/104770315/1dd98ecc-9470-48f1-90f6-c26d73093a32)
