### PR TITLE
Add service migrations (POC)

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -11,6 +11,14 @@
             <argument type="service" id="doctrine.migrations.configuration_loader"/>
             <argument></argument>
             <argument type="service" id="logger" on-invalid="null"></argument>
+            <call method="setDefinition">
+                <argument>Doctrine\Migrations\Finder\MigrationFinder</argument>
+                <argument type="service_closure" id="doctrine.migrations.migration_finder" />
+            </call>
+            <call method="setDefinition">
+                <argument>Doctrine\Migrations\MigrationsRepository</argument>
+                <argument type="service_closure" id="doctrine.migrations.migrations_repository" />
+            </call>
         </service>
 
         <service id="doctrine.migrations.configuration_loader" class="Doctrine\Migrations\Configuration\Migration\ExistingConfiguration" public="false">
@@ -144,6 +152,38 @@
             <argument>doctrine:migrations:version</argument>
 
             <tag name="console.command" command="doctrine:migrations:version" />
+        </service>
+
+        <service id="doctrine.migrations.connection" class="Doctrine\DBAL\Connection">
+            <factory service="doctrine.migrations.dependency_factory" method="getConnection" />
+        </service>
+
+        <service id="doctrine.migrations.logger" class="Psr\Log\LoggerInterface">
+            <factory service="doctrine.migrations.dependency_factory" method="getLogger" />
+        </service>
+
+        <service id="doctrine.migrations.migration_finder" class="Doctrine\Migrations\Finder\MigrationFinder">
+            <factory service="doctrine.migrations.dependency_factory" method="getMigrationsFinder" />
+        </service>
+
+        <service id="doctrine.migrations.filter_service_migration_finder"
+                 class="Doctrine\Bundle\MigrationsBundle\MigrationFinder\FilterServiceMigrationFinder"
+                 decorates="doctrine.migrations.migration_finder"
+        >
+            <argument id="doctrine.migrations.filter_service_migration_finder.inner" type="service" />
+            <argument type="abstract">migrations locator</argument>
+        </service>
+
+        <service id="doctrine.migrations.migrations_repository" class="Doctrine\Migrations\MigrationsRepository">
+            <factory service="doctrine.migrations.dependency_factory" method="getMigrationRepository" />
+        </service>
+
+        <service id="doctrine.migrations.service_migrations_repository"
+                 class="Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository"
+                 decorates="doctrine.migrations.migrations_repository"
+        >
+            <argument id="doctrine.migrations.service_migrations_repository.inner" type="service" />
+            <argument type="abstract">migrations locator</argument>
         </service>
 
     </services>

--- a/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
+++ b/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+class RegisterMigrationsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $migrationRefs = [];
+
+        foreach ($container->findTaggedServiceIds('doctrine_migrations.migration', true) as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+            $definition->setBindings([
+                Connection::class => new BoundArgument(new Reference('doctrine.migrations.connection')),
+                LoggerInterface::class => new BoundArgument(new Reference('doctrine.migrations.logger')),
+            ]);
+
+            $migrationRefs[$id] = new TypedReference($id, $definition->getClass());
+        }
+
+        if ($migrationRefs !== []) {
+            $container->getDefinition('doctrine.migrations.filter_service_migration_finder')
+                ->replaceArgument(1, new ServiceLocatorArgument($migrationRefs));
+            $container->getDefinition('doctrine.migrations.service_migrations_repository')
+                ->replaceArgument(1, new ServiceLocatorArgument($migrationRefs));
+        } else {
+            $container->removeDefinition('doctrine.migrations.connection');
+            $container->removeDefinition('doctrine.migrations.logger');
+            $container->removeDefinition('doctrine.migrations.filter_service_migration_finder');
+            $container->removeDefinition('doctrine.migrations.service_migrations_repository');
+        }
+    }
+}

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 
 use Doctrine\Bundle\MigrationsBundle\Collector\MigrationsCollector;
 use Doctrine\Bundle\MigrationsBundle\Collector\MigrationsFlattener;
+use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
 use Doctrine\Migrations\Version\MigrationFactory;
@@ -47,6 +48,9 @@ class DoctrineMigrationsExtension extends Extension
         $loader  = new XmlFileLoader($container, $locator);
 
         $loader->load('services.xml');
+
+        $container->registerForAutoconfiguration(AbstractMigration::class)
+            ->addTag('doctrine_migrations.migration');
 
         $configurationDefinition = $container->getDefinition('doctrine.migrations.configuration');
 

--- a/src/DoctrineMigrationsBundle.php
+++ b/src/DoctrineMigrationsBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle;
 
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\ConfigureDependencyFactoryPass;
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -12,10 +13,10 @@ use function dirname;
 
 class DoctrineMigrationsBundle extends Bundle
 {
-    /** @return void */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigureDependencyFactoryPass());
+        $container->addCompilerPass(new RegisterMigrationsPass());
     }
 
     public function getPath(): string

--- a/src/MigrationFinder/FilterServiceMigrationFinder.php
+++ b/src/MigrationFinder/FilterServiceMigrationFinder.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationFinder;
+
+use Doctrine\Migrations\Finder\MigrationFinder;
+use Psr\Container\ContainerInterface;
+
+use function array_values;
+
+final class FilterServiceMigrationFinder implements MigrationFinder
+{
+    /** @var MigrationFinder */
+    private $migrationFinder;
+
+    /** @var ContainerInterface */
+    private $container;
+
+    public function __construct(MigrationFinder $migrationFinder, ContainerInterface $container)
+    {
+        $this->migrationFinder = $migrationFinder;
+        $this->container       = $container;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findMigrations(string $directory, ?string $namespace = null): array
+    {
+        $migrations = $this->migrationFinder->findMigrations(
+            $directory,
+            $namespace
+        );
+
+        foreach ($migrations as $i => $migration) {
+            if (! $this->container->has($migration)) {
+                continue;
+            }
+
+            unset($migrations[$i]);
+        }
+
+        return array_values($migrations);
+    }
+}

--- a/src/MigrationsRepository/ServiceMigrationsRepository.php
+++ b/src/MigrationsRepository/ServiceMigrationsRepository.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\DuplicateMigrationVersion;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
+use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Version\Version;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class ServiceMigrationsRepository implements MigrationsRepository
+{
+    /** @var MigrationsRepository */
+    private $migrationRepository;
+
+    /** @var ServiceProviderInterface<AbstractMigration> */
+    private $container;
+
+    /** @var AvailableMigration[] */
+    private $migrations = [];
+
+    /** @param ServiceProviderInterface<AbstractMigration> $container */
+    public function __construct(
+        MigrationsRepository $migrationRepository,
+        ServiceProviderInterface $container
+    ) {
+        $this->migrationRepository = $migrationRepository;
+        $this->container           = $container;
+    }
+
+    public function hasMigration(string $version): bool
+    {
+        return $this->container->has($version) || $this->migrationRepository->hasMigration($version);
+    }
+
+    public function getMigration(Version $version): AvailableMigration
+    {
+        if (! isset($this->migrations[(string) $version]) && ! $this->loadMigrationFromContainer($version)) {
+            return $this->migrationRepository->getMigration($version);
+        }
+
+        return $this->migrations[(string) $version];
+    }
+
+    /**
+     * Returns a non-sorted set of migrations.
+     */
+    public function getMigrations(): AvailableMigrationsSet
+    {
+        $this->loadMigrationsFromContainer();
+
+        $migrations = $this->migrations;
+        foreach ($this->migrationRepository->getMigrations()->getItems() as $availableMigration) {
+            $version = $availableMigration->getVersion();
+
+            if (isset($migrations[(string) $version])) {
+                throw DuplicateMigrationVersion::new(
+                    (string) $version,
+                    (string) $version
+                );
+            }
+
+            $migrations[(string) $version] = $availableMigration;
+        }
+
+        return new AvailableMigrationsSet($migrations);
+    }
+
+    private function loadMigrationsFromContainer(): void
+    {
+        foreach ($this->container->getProvidedServices() as $id) {
+            if (isset($this->migrations[$id])) {
+                continue;
+            }
+
+            $this->loadMigrationFromContainer(new Version($id));
+        }
+    }
+
+    private function loadMigrationFromContainer(Version $version): bool
+    {
+        if (! $this->container->has((string) $version)) {
+            return false;
+        }
+
+        $migration                           = $this->container->get((string) $version);
+        $this->migrations[(string) $version] = new AvailableMigration($version, $migration);
+
+        return true;
+    }
+}


### PR DESCRIPTION
Inspired by https://github.com/doctrine/DoctrineMigrationsBundle/issues/521#issuecomment-1855593824

This is a proposed implementation for registering migrations as services.

To get this working Symfony needs to be able to autoload migrations:

```json
    "autoload": {
        "psr-4": {
            "App\\": "src/",
            "DoctrineMigrations\\": "migrations/"
        }
    },
```

Then, import the migrations as services:

```yaml
    DoctrineMigrations\:
        resource: '../migrations/'
```

Of course, an alternative approach would be to move the `migrations` folder to `src` and change the namespace to `App\Migrations`.

Once that is done, all you need to do is override the constructor and inject the desired services.

```php
final class Version20240121015756 extends AbstractMigration
{
    public function __construct(
        Connection              $connection,
        LoggerInterface         $logger,
        private RouterInterface $router,
    ) {
        parent::__construct($connection, $logger);
    }

    public function up(Schema $schema): void
    {
        dump($this->router);

        // ...
    }

    // ...
}
```

I haven't added any tests yet, as I was hoping to get some feedback on my approach first.