### PR TITLE
Add support for --complete

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -146,6 +146,11 @@
             <tag name="console.command" command="doctrine:migrations:version" />
         </service>
 
+        <service id="doctrine_migrations.schema_filter_listener" class="Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener">
+            <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" />
+            <tag name="doctrine.dbal.schema_filter" />
+        </service>
+
     </services>
 
 </container>

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -90,15 +90,21 @@ class DoctrineMigrationsExtension extends Extension
             $diDefinition->addMethodCall('setDefinition', [$doctrineId, new Reference($symfonyId)]);
         }
 
-        if (! isset($config['services'][MetadataStorage::class])) {
+        if (isset($config['services'][MetadataStorage::class])) {
+            $container->removeDefinition('doctrine_migrations.schema_filter_listener');
+        } else {
+            $filterDefinition     = $container->getDefinition('doctrine_migrations.schema_filter_listener');
             $storageConfiguration = $config['storage']['table_storage'];
 
             $storageDefinition = new Definition(TableMetadataStorageConfiguration::class);
             $container->setDefinition('doctrine.migrations.storage.table_storage', $storageDefinition);
             $container->setAlias('doctrine.migrations.metadata_storage', 'doctrine.migrations.storage.table_storage');
 
-            if ($storageConfiguration['table_name'] !== null) {
+            if ($storageConfiguration['table_name'] === null) {
+                $filterDefinition->addArgument('doctrine_migration_versions');
+            } else {
                 $storageDefinition->addMethodCall('setTableName', [$storageConfiguration['table_name']]);
+                $filterDefinition->addArgument($storageConfiguration['table_name']);
             }
 
             if ($storageConfiguration['version_column_name'] !== null) {

--- a/src/EventListener/SchemaFilterListener.php
+++ b/src/EventListener/SchemaFilterListener.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\EventListener;
+
+use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+
+/**
+ * Acts as a schema filter that hides the migration metadata table except
+ * when the execution context is that of command inside the migrations
+ * namespace.
+ */
+final class SchemaFilterListener
+{
+    /** @var string */
+    private $configurationTableName;
+
+    public function __construct(string $configurationTableName)
+    {
+        $this->configurationTableName = $configurationTableName;
+    }
+
+    /** @var bool */
+    private $enabled = true;
+
+    /** @param AbstractAsset|string $asset */
+    public function __invoke($asset): bool
+    {
+        if (! $this->enabled) {
+            return true;
+        }
+
+        if ($asset instanceof AbstractAsset) {
+            $asset = $asset->getName();
+        }
+
+        return $asset !== $this->configurationTableName;
+    }
+
+    private function disable(): void
+    {
+        $this->enabled = false;
+    }
+
+    public function onConsoleCommand(ConsoleCommandEvent $event): void
+    {
+        $command = $event->getCommand();
+
+        if (! $command instanceof DoctrineCommand) {
+            return;
+        }
+
+        $this->disable();
+    }
+}

--- a/tests/Collector/EventListener/SchemaFilterListenerTest.php
+++ b/tests/Collector/EventListener/SchemaFilterListenerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Collector\EventListener;
+
+use Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Event\ConsoleCommandEvent;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class SchemaFilterListenerTest extends TestCase
+{
+    public function testItFiltersOutMigrationMetadataTableByDefault(): void
+    {
+        $listener = new SchemaFilterListener('doctrine_migration_versions');
+
+        self::assertFalse($listener(new Table('doctrine_migration_versions')));
+        self::assertTrue($listener(new Table('some_other_table')));
+    }
+
+    public function testItDisablesItselfWhenTheCurrentCommandIsAMigrationsCommand(): void
+    {
+        $listener          = new SchemaFilterListener('doctrine_migration_versions');
+        $migrationsCommand = new class extends DoctrineCommand {
+        };
+
+        $listener->onConsoleCommand(new ConsoleCommandEvent(
+            $migrationsCommand,
+            new ArrayInput([]),
+            new NullOutput()
+        ));
+
+        self::assertTrue($listener(new Table('doctrine_migration_versions')));
+    }
+}


### PR DESCRIPTION
When using `orm:schema-tool:update` together with `--complete`, all assets not described by the current metadata are dropped.

This is an issue when using doctrine/migrations, because not using that option is deprecated, and because when it is used, the table that holds the migrations is dropped as well since it is not described by ORM metadata.

A solution to that is configuring an asset filter that filters out the metadata table except when running commands inside the migrations namespace.

# How can I test this?

```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/DoctrineMigrationsBundle
composer require doctrine/doctrine-migrations-bundle "dev-complete-compat as 3.3.0"
```

