### PR TITLE
Exclude file from static analysis

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,8 +2,8 @@ parameters:
     level: 7
     phpVersion: 80200
     paths:
-        - %currentWorkingDirectory%/DependencyInjection
-        - %currentWorkingDirectory%/Tests
+        - DependencyInjection
+        - Tests
 
     ignoreErrors:
         - '~Parameter \#1 \$configs.*DoctrineMigrationsExtension::load.*~'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,6 +5,10 @@ parameters:
         - DependencyInjection
         - Tests
 
+    excludePaths:
+        # That file contains an error that cannot be ignored
+        - Tests/Fixtures/Migrations/ContainerAwareMigration.php
+
     ignoreErrors:
         - '~Parameter \#1 \$configs.*DoctrineMigrationsExtension::load.*~'
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
+<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
   <file src="DependencyInjection/Configuration.php">
     <UndefinedInterfaceMethod>
-      <code>end</code>
+      <code><![CDATA[end]]></code>
     </UndefinedInterfaceMethod>
   </file>
   <file src="DependencyInjection/DoctrineMigrationsExtension.php">
     <MoreSpecificImplementedParamType>
-      <code>$configs</code>
+      <code><![CDATA[$configs]]></code>
     </MoreSpecificImplementedParamType>
+  </file>
+  <file src="Tests/Fixtures/Migrations/ContainerAwareMigration.php">
+    <UndefinedClass>
+      <code><![CDATA[ContainerAwareInterface]]></code>
+    </UndefinedClass>
   </file>
 </files>


### PR DESCRIPTION
That file contains a class that implements a non-existing interface
(when using Symfony 7+): `ContainerAwareInterface`.