### PR TITLE
Register event listener to remove migration table from comparison schema

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -145,6 +145,11 @@
 
             <tag name="console.command" command="doctrine:migrations:version" />
         </service>
+        <service id="doctrine_migrations.event.listener.remove_migration_table" class="Doctrine\Migrations\Event\Listeners\RemoveMigrationTableFromSchemaListener">
+            <tag name="doctrine.event_listener" event="postGenerateSchema"/>
+            <tag name="doctrine.event_listener" event="postGenerateComparisonSchema"/>
+            <argument type="service" id="doctrine.migrations.dependency_factory"/>
+        </service>
 
     </services>
 


### PR DESCRIPTION
The PR doctrine/orm#11374 is created to add a new event to `doctrine/orm`: `ToolEvents::postGenerateComparisonSchema`. This event enables doctrine/migrations#1418 where the migration version table can be removed from the generated comparison schema.

This PR registers the new event listener with the Symfony container, fixing #1406.

```
> bin/console doctrine:schema:validate

Mapping
-------
                                                                                                             
 [OK] The mapping files are correct.                                                                         
                                                                                                             

Database
--------
                                                                                                             
 [OK] The database schema is in sync with the mapping files.                                                 
                                                                                                             
```

PR relates to an attempt to fix doctrine/migrations#1406. It requires doctrine/orm#11374 and doctrine/migrations#1418.