### PR TITLE
Use service name in the example

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -251,10 +251,9 @@ Here is an example on how to inject the service container into your migrations:
 
         # config/services.yaml
         services:
-            Doctrine\Migrations\Version\DbalMigrationFactory: ~
             App\Migrations\Factory\MigrationFactoryDecorator:
-                decorates: Doctrine\Migrations\Version\DbalMigrationFactory
-                arguments: ['@App\Migrations\Factory\MigrationFactoryDecorator.inner', '@service_container']
+                decorates: 'doctrine.migrations.migrations_factory'
+                arguments: ['@.inner', '@service_container']
 
 
 .. code-block:: php


### PR DESCRIPTION
By defining a new service for `Doctrine\Migrations\Version\DbalMigrationFactory` you overwrite the existing factory. The existing factory definition however is more complex when you have multiple connections defined. The connection is determined by the arguments passed to the console command. The original example breaks this behavior. 

By now the example is using the exiting service to decorate, allowing people with multiple connections to create a new decorator without breaking the behavior.