### PR TITLE
Switch to non-deprecated Extension class

### DIFF
--- a/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/DependencyInjection/DoctrineMigrationsExtension.php
@@ -16,9 +16,9 @@ use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 use function array_keys;
 use function assert;
@@ -30,16 +30,12 @@ use function sprintf;
 use function strlen;
 use function substr;
 
-/**
- * DoctrineMigrationsExtension.
- */
 class DoctrineMigrationsExtension extends Extension
 {
     /**
      * Responds to the migrations configuration parameter.
      *
-     * @param mixed[][] $configs
-     * @psalm-param array<string, array<string, array<string, array<string, string>|string>|string>> $configs
+     * {@inheritDoc}
      */
     public function load(array $configs, ContainerBuilder $container): void
     {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,9 +12,6 @@ parameters:
         # That file contains an error that cannot be ignored
         - Tests/Fixtures/Migrations/ContainerAwareMigration.php
 
-    ignoreErrors:
-        - '~Parameter \#1 \$configs.*DoctrineMigrationsExtension::load.*~'
-
 includes:
     - phpstan-baseline.neon
     - vendor/phpstan/phpstan-strict-rules/rules.neon

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,14 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.23.1@8471a896ccea3526b26d082f4461eeea467f10a4">
+<files psalm-version="5.24.0@462c80e31c34e58cc4f750c656be3927e80e550e">
   <file src="DependencyInjection/Configuration.php">
     <UndefinedInterfaceMethod>
       <code><![CDATA[end]]></code>
     </UndefinedInterfaceMethod>
-  </file>
-  <file src="DependencyInjection/DoctrineMigrationsExtension.php">
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$configs]]></code>
-    </MoreSpecificImplementedParamType>
   </file>
   <file src="MigrationsFactory/ContainerAwareMigrationFactory.php">
     <ContainerDependency>


### PR DESCRIPTION
Symfony deprecated the abstract extension class from the `HttpKernel` component. Let's use its parent from the DependencyInjection component instead.