### PR TITLE
Update doc for dependencies injection and Symfony 7

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -300,7 +300,7 @@ Here is an example on how to inject the service container into your migrations:
 .. caution::
 
     The interface ``Symfony\Component\DependencyInjection\ContainerAwareInterface`` has been deprecated in Symfony 6.4 and
-    removed in 7.0. If you use this version or newer, there is currently no way to inject dependencies in migrations.
+    removed in 7.0. If you use this version or newer, there is currently no way to inject service container in migrations.
 
 
 Generating Migrations Automatically

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -300,7 +300,7 @@ Here is an example on how to inject the service container into your migrations:
 .. caution::
 
     The interface ``Symfony\Component\DependencyInjection\ContainerAwareInterface`` has been deprecated in Symfony 6.4 and
-    removed in 7.0. If you use this version or newer, there is currently no way to inject service container in migrations.
+    removed in 7.0. If you use this version or newer, there is currently no way to inject the service container into migrations.
 
 
 Generating Migrations Automatically

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -297,6 +297,11 @@ Here is an example on how to inject the service container into your migrations:
     this bundle will automatically inject the default symfony container into your migration class
     (this because the ``MigrationFactoryDecorator`` shown in this example is the default migration factory used by this bundle).
 
+.. caution::
+
+    The interface ``Symfony\Component\DependencyInjection\ContainerAwareInterface`` has been deprecated in Symfony 6.4 and
+    removed in 7.0. If you use this version or newer, there is currently no way to inject dependencies in migrations.
+
 
 Generating Migrations Automatically
 -----------------------------------


### PR DESCRIPTION
Related to #521 
Update doc to mention this interface is no longer available starting from SF 7+
Considering this bundle can be used with older versions I think this isn't necessary to remove this part as it can be useful for some projects