### PR TITLE
Drop unsupported versions of PHP

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -14,7 +14,7 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@7.1.0"
     with:
-      php-versions: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+      php-versions: '["8.1", "8.2", "8.3", "8.4"]'
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -79,8 +79,8 @@ doctrine_migrations:
 ### Underlying doctrine/migrations library
 
 Upgrading this bundle to `3.0` will also update the `doctrine/migrations` library to the version `3.0`.
-Backward incompatible changes in `doctrine/migrations` 3.0 
-are documented in the dedicated [UPGRADE](https://github.com/doctrine/migrations/blob/3.0.x/UPGRADE.md) document. 
+Backward incompatible changes in `doctrine/migrations` 3.0
+are documented in the dedicated [UPGRADE](https://github.com/doctrine/migrations/blob/3.0.x/UPGRADE.md) document.
 
 - The container is not automatically injected anymore when a migration implements `ContainerAwareInterface`. Custom
 migration factories should be used to inject additional dependencies into migrations.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,12 @@
 # Upgrade
 
+## 4.0.0
+
+### BC break: type declarations
+
+Type declarations have been added to all method signatures and properties. You
+might have to adjust your own code to abide by the new type declarations.
+
 ## From 2.x to 3.0.0
 
 - The configuration for the migration namespace and directory changed as follows:

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^8.1",
         "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
         "doctrine/doctrine-bundle": "^2.4",
@@ -28,17 +28,18 @@
     },
     "require-dev": {
         "composer/semver": "^3.0",
-        "phpunit/phpunit": "^8.5|^9.5",
+        "phpunit/phpunit": "^9.6.22",
         "doctrine/coding-standard": "^12",
-        "phpstan/phpstan": "^1.4 || ^2",
-        "phpstan/phpstan-deprecation-rules": "^1 || ^2",
-        "phpstan/phpstan-phpunit": "^1 || ^2",
-        "phpstan/phpstan-strict-rules": "^1.1 || ^2",
-        "phpstan/phpstan-symfony": "^1.3 || ^2",
+        "phpstan/phpstan": "^2",
+        "phpstan/phpstan-deprecation-rules": "^2",
+        "phpstan/phpstan-phpunit": "^2",
+        "phpstan/phpstan-strict-rules": "^2",
+        "phpstan/phpstan-symfony": "^2",
         "doctrine/orm": "^2.6 || ^3",
         "doctrine/persistence": "^2.0 || ^3 ",
-        "symfony/phpunit-bridge": "^6.3 || ^7",
-        "symfony/var-exporter": "^5.4 || ^6 || ^7"
+        "symfony/console": "^6.4.17 || ^7.0",
+        "symfony/phpunit-bridge": "^7",
+        "symfony/var-exporter": "^6 || ^7"
     },
     "autoload": {
         "psr-4": { "Doctrine\\Bundle\\MigrationsBundle\\": "src" }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -12,7 +12,7 @@
     <!-- Ignore warnings, show progress of the run and show sniff names -->
     <arg value="nps"/>
 
-    <config name="php_version" value="70200"/>
+    <config name="php_version" value="80100"/>
 
     <file>src</file>
     <file>tests</file>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,11 +19,7 @@
 
     <exclude-pattern>tests/Fixtures/CustomEntityManager.php</exclude-pattern>
 
-    <rule ref="Doctrine">
-        <exclude name="SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.ReturnTypeHint.MissingNativeTypeHint" />
-        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint" />
-    </rule>
+    <rule ref="Doctrine" />
 
     <!-- Disable the rules that will require PHP 7.4 -->
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -69,20 +69,18 @@ class MigrationsCollector extends DataCollector
         $this->data['namespaces'] = $configuration->getMigrationDirectories();
     }
 
-    /** @return string */
-    public function getName()
+    public function getName(): string
     {
         return 'doctrine_migrations';
     }
 
     /** @return array<string, mixed>|Data */
-    public function getData()
+    public function getData(): array|Data
     {
         return $this->data;
     }
 
-    /** @return void */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -18,19 +18,13 @@ use function get_class;
 
 class MigrationsCollector extends DataCollector
 {
-    /** @var DependencyFactory */
-    private $dependencyFactory;
-    /** @var MigrationsFlattener */
-    private $flattener;
-
-    public function __construct(DependencyFactory $dependencyFactory, MigrationsFlattener $migrationsFlattener)
-    {
-        $this->dependencyFactory = $dependencyFactory;
-        $this->flattener         = $migrationsFlattener;
+    public function __construct(
+        private DependencyFactory $dependencyFactory,
+        private MigrationsFlattener $flattener,
+    ) {
     }
 
-    /** @return void */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, Throwable|null $exception = null): void
     {
         if ($this->data !== []) {
             return;
@@ -44,7 +38,7 @@ class MigrationsCollector extends DataCollector
         } catch (Exception $dbalException) {
             $this->dependencyFactory->getLogger()->error(
                 'error while trying to collect executed migrations',
-                ['exception' => $dbalException]
+                ['exception' => $dbalException],
             );
 
             return;
@@ -60,7 +54,7 @@ class MigrationsCollector extends DataCollector
         $this->data['new_migrations']      = $this->flattener->flattenAvailableMigrations($newMigrations);
         $this->data['executed_migrations'] = $this->flattener->flattenExecutedMigrations($executedMigrations, $availableMigrations);
 
-        $this->data['storage'] = get_class($metadataStorage);
+        $this->data['storage'] = $metadataStorage::class;
         $configuration         = $this->dependencyFactory->getConfiguration();
         $storage               = $configuration->getMetadataStorageConfiguration();
         if ($storage instanceof TableMetadataStorageConfiguration) {

--- a/src/Collector/MigrationsFlattener.php
+++ b/src/Collector/MigrationsFlattener.php
@@ -63,7 +63,7 @@ class MigrationsFlattener
                 'version' => (string) $migration->getVersion(),
                 'is_new' => false,
                 'is_unavailable' => $availableMigration === null,
-                'description' => $availableMigration !== null ? $availableMigration->getDescription() : null,
+                'description' => $availableMigration?->getDescription(),
                 'executed_at' => $migration->getExecutedAt(),
                 'execution_time' => $migration->getExecutionTime(),
                 'file' => $availableMigration !== null ? (new ReflectionClass($availableMigration))->getFileName() : null,

--- a/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
@@ -84,7 +84,7 @@ class ConfigureDependencyFactoryPass implements CompilerPassInterface
             throw new InvalidArgumentException(sprintf(
                 'The "%s" connection is not defined. Did you mean one of the following: %s',
                 $preferredConnection,
-                implode(', ', array_keys($allowedConnections))
+                implode(', ', array_keys($allowedConnections)),
             ));
         }
     }
@@ -98,7 +98,7 @@ class ConfigureDependencyFactoryPass implements CompilerPassInterface
         ) {
             throw new InvalidArgumentException(sprintf(
                 'The "%s" entity manager is not defined. It seems that you do not have configured any entity manager in the DoctrineBundle.',
-                $preferredEm
+                $preferredEm,
             ));
         }
 
@@ -108,7 +108,7 @@ class ConfigureDependencyFactoryPass implements CompilerPassInterface
             throw new InvalidArgumentException(sprintf(
                 'The "%s" entity manager is not defined. Did you mean one of the following: %s',
                 $preferredEm,
-                implode(', ', array_keys($allowedEms))
+                implode(', ', array_keys($allowedEms)),
             ));
         }
     }

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -122,7 +122,7 @@ class DoctrineMigrationsExtension extends Extension
 
         if ($config['em'] !== null && $config['connection'] !== null) {
             throw new InvalidArgumentException(
-                'You cannot specify both "connection" and "em" in the DoctrineMigrationsBundle configurations.'
+                'You cannot specify both "connection" and "em" in the DoctrineMigrationsBundle configurations.',
             );
         }
 
@@ -159,7 +159,7 @@ class DoctrineMigrationsExtension extends Extension
             throw new RuntimeException(sprintf(
                 'The bundle "%s" has not been registered, available bundles: %s',
                 $bundleName,
-                implode(', ', array_keys($bundleMetadata))
+                implode(', ', array_keys($bundleMetadata)),
             ));
         }
 

--- a/src/DoctrineMigrationsBundle.php
+++ b/src/DoctrineMigrationsBundle.php
@@ -12,8 +12,7 @@ use function dirname;
 
 class DoctrineMigrationsBundle extends Bundle
 {
-    /** @return void */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigureDependencyFactoryPass());
     }

--- a/src/MigrationsFactory/ContainerAwareMigrationFactory.php
+++ b/src/MigrationsFactory/ContainerAwareMigrationFactory.php
@@ -14,16 +14,10 @@ use function trigger_deprecation;
 /** @deprecated This class is not compatible with Symfony >= 7 */
 class ContainerAwareMigrationFactory implements MigrationFactory
 {
-    /** @var ContainerInterface */
-    private $container;
-
-    /** @var MigrationFactory */
-    private $migrationFactory;
-
-    public function __construct(MigrationFactory $migrationFactory, ContainerInterface $container)
-    {
-        $this->container        = $container;
-        $this->migrationFactory = $migrationFactory;
+    public function __construct(
+        private MigrationFactory $migrationFactory,
+        private ContainerInterface $container,
+    ) {
     }
 
     public function createVersion(string $migrationClassName): AbstractMigration

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -130,7 +130,7 @@ class DoctrineMigrationsExtensionTest extends TestCase
         ], $config->getMigrationDirectories());
     }
 
-    private function assertConfigs(?object $config): void
+    private function assertConfigs(object|null $config): void
     {
         self::assertInstanceOf(Configuration::class, $config);
         self::assertSame([
@@ -459,7 +459,7 @@ class DoctrineMigrationsExtensionTest extends TestCase
      * @param mixed[]|null $dbalConfig
      * @param mixed[]|null $ormConfig
      */
-    private function getContainer(array $config, ?array $dbalConfig = null, ?array $ormConfig = null): ContainerBuilder
+    private function getContainer(array $config, array|null $dbalConfig = null, array|null $ormConfig = null): ContainerBuilder
     {
         $container = $this->getContainerBuilder();
 

--- a/tests/Fixtures/Migrations/ContainerAwareMigration.php
+++ b/tests/Fixtures/Migrations/ContainerAwareMigration.php
@@ -18,12 +18,12 @@ class ContainerAwareMigration extends AbstractMigration implements ContainerAwar
     {
     }
 
-    public function setContainer(?ContainerInterface $container = null): void
+    public function setContainer(ContainerInterface|null $container = null): void
     {
         $this->container = $container;
     }
 
-    public function getContainer(): ?ContainerInterface
+    public function getContainer(): ContainerInterface|null
     {
         return $this->container;
     }


### PR DESCRIPTION
This should allow us to do many breaking changes related to new features of PHP.

I'm buping to 8.1 and not higher for the sake of consistency with other recent versions of Doctrine packages. Do let me know if you think I should bump higher.