### PR TITLE
Upgrade to PHPUnit 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     },
     "require-dev": {
         "composer/semver": "^3.0",
-        "phpunit/phpunit": "^9.6.22",
+        "phpunit/phpunit": "^10.5.40 || ^11.5",
         "doctrine/coding-standard": "^12",
         "phpstan/phpstan": "^2",
         "phpstan/phpstan-deprecation-rules": "^2",
@@ -37,8 +37,6 @@
         "phpstan/phpstan-symfony": "^2",
         "doctrine/orm": "^2.6 || ^3",
         "doctrine/persistence": "^2.0 || ^3 ",
-        "symfony/console": "^6.4.17 || ^7.0",
-        "symfony/phpunit-bridge": "^7",
         "symfony/var-exporter": "^6 || ^7"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="vendor/autoload.php">
+<phpunit
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    colors="true"
+    bootstrap="vendor/autoload.php"
+    displayDetailsOnTestsThatTriggerDeprecations="true"
+>
     <testsuites>
         <testsuite name="DoctrineMigrationsBundle for the Symfony Framework">
             <directory>./tests</directory>
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <source ignoreSuppressionOfDeprecations="true">
+        <include>
             <directory>src</directory>
-        </whitelist>
-    </filter>
+        </include>
+    </source>
 
-    <listeners>
-        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
-    </listeners>
+    <php>
+        <server name="DOCTRINE_DEPRECATIONS" value="trigger"/>
+    </php>
 </phpunit>

--- a/tests/DependencyInjection/DoctrineCommandsTest.php
+++ b/tests/DependencyInjection/DoctrineCommandsTest.php
@@ -21,6 +21,7 @@ use Doctrine\Migrations\Tools\Console\Command\StatusCommand;
 use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -34,11 +35,8 @@ use function sys_get_temp_dir;
 
 class DoctrineCommandsTest extends TestCase
 {
-    /**
-     * @param class-string<DoctrineCommand> $instance
-     *
-     * @dataProvider getCommands
-     */
+    /** @param class-string<DoctrineCommand> $instance */
+    #[DataProvider('getCommands')]
     public function testCommandRegistered(string $name, string $instance): void
     {
         $command = $this->getApplication()->find($name);
@@ -53,7 +51,7 @@ class DoctrineCommandsTest extends TestCase
      * @return string[][]
      * @phpstan-return list<array{string, class-string<DoctrineCommand>}>
      */
-    public function getCommands(): array
+    public static function getCommands(): array
     {
         return [
             ['doctrine:migrations:diff', DiffCommand::class],

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -23,7 +23,6 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
-use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
@@ -40,8 +39,6 @@ use function trait_exists;
 
 class DoctrineMigrationsExtensionTest extends TestCase
 {
-    use ExpectDeprecationTrait;
-
     public function testXmlConfigs(): void
     {
         $container = $this->getContainerBuilder();


### PR DESCRIPTION
The use of listeners is no longer possible, but we can replace the deprecation detection functionality with native PHPUnit features.