### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,16 +4,22 @@
   "slug": "doctrine-migrations-bundle",
   "versions": [
     {
-      "name": "3.4",
-      "branchName": "3.4.x",
+      "name": "4.0",
+      "branchName": "4.0.x",
       "slug": "latest",
       "upcoming": true
+    },
+    {
+      "name": "3.4",
+      "branchName": "3.4.x",
+      "slug": "3.4",
+      "current": true
     },
     {
       "name": "3.3",
       "branchName": "3.3.x",
       "slug": "3.3",
-      "current": true
+      "maintained": false
     },
     {
       "name": "3.2",

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,4 +1,4 @@
-branches: ["2.2.x", "3.0.x", "3.1.x", "3.2.x", "3.3.x", "3.4.x"]
-maintained_branches: ["2.2.x", "3.3.x", "3.4.x"]
-doc_dir: {"2.2.x": "Resources/doc/", "3.3.x": "Resources/doc/", "3.4.x": "docs/"}
+branches: ["3.0.x", "3.1.x", "3.2.x", "3.3.x", "3.4.x", "4.0.x"]
+maintained_branches: ["3.4.x", "4.0.x"]
+doc_dir: "docs/"
 dev_branch: "3.4.x"


### PR DESCRIPTION
- We can stop maintenance on 2.x, nobody seems to be using it now.
- 3.3.x is no longer maintained
- 3.4.x is the new current branch
- 4.0.x is the new latest branch, and is upcoming

No 3.5.x, because I think we could release 4.0.0 quite soon.