### PR TITLE
Apply schema filter more selectively

### DIFF
--- a/src/EventListener/SchemaFilterListener.php
+++ b/src/EventListener/SchemaFilterListener.php
@@ -40,11 +40,6 @@ final class SchemaFilterListener
         return $asset !== $this->configurationTableName;
     }
 
-    private function disable(): void
-    {
-        $this->enabled = false;
-    }
-
     public function onConsoleCommand(ConsoleCommandEvent $event): void
     {
         $command = $event->getCommand();
@@ -53,6 +48,6 @@ final class SchemaFilterListener
             return;
         }
 
-        $this->disable();
+        $this->enabled = false;
     }
 }

--- a/src/EventListener/SchemaFilterListener.php
+++ b/src/EventListener/SchemaFilterListener.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\EventListener;
 
 use Doctrine\DBAL\Schema\AbstractAsset;
-use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 
 /**
@@ -24,7 +25,7 @@ final class SchemaFilterListener
     }
 
     /** @var bool */
-    private $enabled = true;
+    private $enabled = false;
 
     /** @param AbstractAsset|string $asset */
     public function __invoke($asset): bool
@@ -44,10 +45,10 @@ final class SchemaFilterListener
     {
         $command = $event->getCommand();
 
-        if (! $command instanceof DoctrineCommand) {
+        if (! $command instanceof ValidateSchemaCommand && ! $command instanceof UpdateCommand) {
             return;
         }
 
-        $this->enabled = false;
+        $this->enabled = true;
     }
 }

--- a/tests/Collector/EventListener/SchemaFilterListenerTest.php
+++ b/tests/Collector/EventListener/SchemaFilterListenerTest.php
@@ -7,6 +7,10 @@ namespace Doctrine\Bundle\MigrationsBundle\Tests\Collector\EventListener;
 use Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener;
 use Doctrine\DBAL\Schema\Table;
 use Doctrine\Migrations\Tools\Console\Command\DoctrineCommand;
+use Doctrine\ORM\Tools\Console\Command\AbstractEntityManagerCommand;
+use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
+use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
+use Doctrine\ORM\Tools\Console\EntityManagerProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Event\ConsoleCommandEvent;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -14,18 +18,17 @@ use Symfony\Component\Console\Output\NullOutput;
 
 class SchemaFilterListenerTest extends TestCase
 {
-    public function testItFiltersOutMigrationMetadataTableByDefault(): void
+    public function testItFiltersNothingByDefault(): void
     {
         $listener = new SchemaFilterListener('doctrine_migration_versions');
-
-        self::assertFalse($listener(new Table('doctrine_migration_versions')));
+        self::assertTrue($listener(new Table('doctrine_migration_versions')));
         self::assertTrue($listener(new Table('some_other_table')));
     }
 
-    public function testItDisablesItselfWhenTheCurrentCommandIsAMigrationsCommand(): void
+    public function testItFiltersNothingWhenNotRunningSpecificCommands(): void
     {
         $listener          = new SchemaFilterListener('doctrine_migration_versions');
-        $migrationsCommand = new class extends DoctrineCommand {
+        $migrationsCommand = new class () extends DoctrineCommand {
         };
 
         $listener->onConsoleCommand(new ConsoleCommandEvent(
@@ -35,5 +38,33 @@ class SchemaFilterListenerTest extends TestCase
         ));
 
         self::assertTrue($listener(new Table('doctrine_migration_versions')));
+        self::assertTrue($listener(new Table('some_other_table')));
+    }
+
+    /**
+     * @param class-string<AbstractEntityManagerCommand> $command
+     *
+     * @dataProvider getCommands
+     */
+    public function testItFiltersOutMigrationMetadataTableWhenRunningSpecificCommands(string $command): void
+    {
+        $listener   = new SchemaFilterListener('doctrine_migration_versions');
+        $ormCommand = new $command($this->createStub(EntityManagerProvider::class));
+
+        $listener->onConsoleCommand(new ConsoleCommandEvent(
+            $ormCommand,
+            new ArrayInput([]),
+            new NullOutput()
+        ));
+
+        self::assertFalse($listener(new Table('doctrine_migration_versions')));
+        self::assertTrue($listener(new Table('some_other_table')));
+    }
+
+    /** @return iterable<string, array{class-string<AbstractEntityManagerCommand>}> */
+    public static function getCommands(): iterable
+    {
+        yield 'orm:validate-schema' => [ValidateSchemaCommand::class];
+        yield 'orm:schema-tool:update' => [UpdateCommand::class];
     }
 }


### PR DESCRIPTION
It is more careful, since there seems to be a lot of situations where we do not want to apply the filter.
Let us take the opposite approach and:
- Have the filter disabled by default, instead of enabled by default.
- Enable it for precise commands where we know we need it.

This means the ORM is no longer just a dev dependency.

Fixes #584, fixes #585

# How can I test this?
```shell
composer config repositories.greg0ire vcs https://github.com/greg0ire/DoctrineMigrationsBundle
composer require doctrine/doctrine-migrations-bundle "dev-selective-filter as 3.4.0"
```