### PR TITLE
Add support for multiple connections managed by migrations

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -148,7 +148,7 @@
 
         <service id="doctrine_migrations.schema_filter_listener" class="Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener">
             <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" />
-<!--            <tag name="doctrine.dbal.schema_filter" /> This tag is dynamically added for each connection-->
+<!--        <tag name="doctrine.dbal.schema_filter" /> This tag is dynamically added for each connection -->
         </service>
 
     </services>

--- a/config/services.xml
+++ b/config/services.xml
@@ -148,7 +148,7 @@
 
         <service id="doctrine_migrations.schema_filter_listener" class="Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener">
             <tag name="kernel.event_listener" event="console.command" method="onConsoleCommand" />
-            <tag name="doctrine.dbal.schema_filter" />
+<!--            <tag name="doctrine.dbal.schema_filter" /> This tag is dynamically added for each connection-->
         </service>
 
     </services>

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -124,6 +124,15 @@ class DoctrineMigrationsExtension extends Extension
             }
 
             $configurationDefinition->addMethodCall('setMetadataStorageConfiguration', [new Reference('doctrine.migrations.storage.table_storage')]);
+
+            // Add tag to the filter for each Doctrine connection, so the table is ignored for multiple connections
+            if ($container->hasParameter('doctrine.connections')) {
+                /** @var array<string, string> $connections */
+                $connections = $container->getParameter('doctrine.connections');
+                foreach (array_keys($connections) as $connection) {
+                    $filterDefinition->addTag('doctrine.dbal.schema_filter', ['connection' => $connection]);
+                }
+            }
         }
 
         if ($config['em'] !== null && $config['connection'] !== null) {

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -279,6 +279,10 @@ class DoctrineMigrationsExtensionTest extends TestCase
         $di = $container->get('doctrine.migrations.dependency_factory');
         self::assertInstanceOf(DependencyFactory::class, $di);
         self::assertSame($doctrine->getConnection('custom'), $di->getConnection());
+        // Check if the multiple connections also added the required tags to the filter
+        $filterDefinition = $container->findDefinition('doctrine_migrations.schema_filter_listener');
+        $tags             = $filterDefinition->getTag('doctrine.dbal.schema_filter');
+        self::assertCount(2, $tags);
     }
 
     public function testPrefersEntityManagerOverConnection(): void
@@ -466,9 +470,6 @@ class DoctrineMigrationsExtensionTest extends TestCase
         $bundle = new DoctrineMigrationsBundle();
         $bundle->build($container);
 
-        $extension = new DoctrineMigrationsExtension();
-        $extension->load(['doctrine_migrations' => $config], $container);
-
         $extension = new DoctrineExtension();
 
         $doctrineBundleConfigs = $dbalConfig === null ? ['dbal' => ['url' => 'sqlite:///:memory:']] : ['dbal' => $dbalConfig];
@@ -478,8 +479,15 @@ class DoctrineMigrationsExtensionTest extends TestCase
 
         $extension->load(['doctrine' => $doctrineBundleConfigs], $container);
 
+        $extension = new DoctrineMigrationsExtension();
+        $extension->load(['doctrine_migrations' => $config], $container);
+
         $container->getDefinition('doctrine.migrations.dependency_factory')->setPublic(true);
         $container->getDefinition('doctrine.migrations.configuration')->setPublic(true);
+        if ($container->hasDefinition('doctrine_migrations.schema_filter_listener')) {
+            $container->getDefinition('doctrine_migrations.schema_filter_listener')->setPublic(true);
+        }
+
         $container->addCompilerPass(new CacheCompatibilityPass());
 
         return $container;


### PR DESCRIPTION
References https://github.com/doctrine/migrations/issues/1406, which fixes the filtering of the migrations table for the default connection but not for any other connections.
This PR applies the filter to each of the Doctrine connections.
Not sure what else is required in terms of tests/documentation etc.