### PR TITLE
Make classes internal

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,10 +2,10 @@
 
 ## 4.0.0
 
-## BC break: final classes
+## BC break: final, internal classes
 
-Some classes have been marked as `final` because they are not supposed to be
-extended. Consider using composition instead of inheritance.
+Some classes have been marked as `final` and `@internal` because they are not
+supposed to be extended or even referenced outside of the bundle.
 
 ### BC break: type declarations
 

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -16,6 +16,7 @@ use Throwable;
 use function count;
 use function get_class;
 
+/** @internal */
 final class MigrationsCollector extends DataCollector
 {
     public function __construct(

--- a/src/Collector/MigrationsFlattener.php
+++ b/src/Collector/MigrationsFlattener.php
@@ -13,6 +13,7 @@ use ReflectionClass;
 
 use function array_map;
 
+/** @internal */
 final class MigrationsFlattener
 {
     /**

--- a/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
@@ -19,6 +19,7 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
+/** @internal */
 final class ConfigureDependencyFactoryPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ use function strlen;
 use function strtoupper;
 use function substr;
 
+/** @internal */
 final class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -28,6 +28,7 @@ use function sprintf;
 use function strlen;
 use function substr;
 
+/** @internal */
 final class DoctrineMigrationsExtension extends Extension
 {
     /**

--- a/src/EventListener/SchemaFilterListener.php
+++ b/src/EventListener/SchemaFilterListener.php
@@ -13,6 +13,8 @@ use Symfony\Component\Console\Event\ConsoleCommandEvent;
  * Acts as a schema filter that hides the migration metadata table except
  * when the execution context is that of command inside the migrations
  * namespace.
+ *
+ * @internal
  */
 final class SchemaFilterListener
 {


### PR DESCRIPTION
I believe there is only one class that should not be made internal, and that's the bundle class. For all other classes, I do not think they should be referenced by external code.