### PR TITLE
Mark classes as final with an annotation

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,13 @@
 # Upgrade
 
+## Upgrade to 3.5
+
+## Final classes
+
+Some classes have been marked as `@final` because they are not supposed to be
+extended. They will be `final`, and most of them will be marked with
+`@internal` in 4.0.0.
+
 ## From 2.x to 3.0.0
 
 - The configuration for the migration namespace and directory changed as follows:
@@ -79,8 +87,8 @@ doctrine_migrations:
 ### Underlying doctrine/migrations library
 
 Upgrading this bundle to `3.0` will also update the `doctrine/migrations` library to the version `3.0`.
-Backward incompatible changes in `doctrine/migrations` 3.0 
-are documented in the dedicated [UPGRADE](https://github.com/doctrine/migrations/blob/3.0.x/UPGRADE.md) document. 
+Backward incompatible changes in `doctrine/migrations` 3.0
+are documented in the dedicated [UPGRADE](https://github.com/doctrine/migrations/blob/3.0.x/UPGRADE.md) document.
 
 - The container is not automatically injected anymore when a migration implements `ContainerAwareInterface`. Custom
 migration factories should be used to inject additional dependencies into migrations.

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -16,6 +16,7 @@ use Throwable;
 use function count;
 use function get_class;
 
+/** @final */
 class MigrationsCollector extends DataCollector
 {
     /** @var DependencyFactory */

--- a/src/Collector/MigrationsFlattener.php
+++ b/src/Collector/MigrationsFlattener.php
@@ -13,6 +13,7 @@ use ReflectionClass;
 
 use function array_map;
 
+/** @final */
 class MigrationsFlattener
 {
     /**

--- a/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/ConfigureDependencyFactoryPass.php
@@ -19,6 +19,7 @@ use function is_array;
 use function is_string;
 use function sprintf;
 
+/** @final */
 class ConfigureDependencyFactoryPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container): void

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,6 +19,7 @@ use function strpos;
 use function strtoupper;
 use function substr;
 
+/** @final */
 class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -30,6 +30,7 @@ use function sprintf;
 use function strlen;
 use function substr;
 
+/** @final */
 class DoctrineMigrationsExtension extends Extension
 {
     /**

--- a/src/DoctrineMigrationsBundle.php
+++ b/src/DoctrineMigrationsBundle.php
@@ -10,6 +10,7 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 use function dirname;
 
+/** @final */
 class DoctrineMigrationsBundle extends Bundle
 {
     /** @return void */


### PR DESCRIPTION
This can serve as a deprecation warning for people extending those classes.