### PR TITLE
Fix doctrine types attribute in documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -332,10 +332,10 @@ for Doctrine's ORM:
         {
             #[ORM\Id]
             #[ORM\GeneratedValue(strategy: 'AUTO')]
-            #[ORM\Column(type: Types:INT)]
+            #[ORM\Column(type: Types::INTEGER)]
             private $id;
 
-            #[ORM\Column(type: Types:STRING, length: 255)]
+            #[ORM\Column(type: Types::STRING, length: 255)]
             private $name;
 
     .. code-block:: php-annotations


### PR DESCRIPTION
Hello

I fixed 2 issues in the documentation:
1) PHP syntax: `Types:STRING` -> `Types::STRING`
2) Replaces wrong `Types::INT` constant by `Types::INTEGER` option (see https://github.com/doctrine/dbal/blob/4.3.x/src/Types/Types.php)