### PR TITLE
Update the Symfony bundle configuration

### DIFF
--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,4 +1,4 @@
-branches: ["3.0.x", "3.1.x", "3.2.x", "3.3.x", "3.4.x", "4.0.x"]
-maintained_branches: ["3.4.x", "4.0.x"]
+branches: ["3.0.x", "3.1.x", "3.2.x", "3.3.x", "3.4.x", "3.5.x", "4.0.x"]
+maintained_branches: ["3.5.x", "4.0.x"]
 doc_dir: "docs/"
-dev_branch: "3.4.x"
+dev_branch: "4.0.x"


### PR DESCRIPTION
Without this fix, the doc is not available because `3.5.x` branch doesn't exist in the config file. See https://symfony.com/bundles/DoctrineMigrationsBundle/current/index.html