### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -10,10 +10,22 @@
       "upcoming": true
     },
     {
+      "name": "3.6",
+      "branchName": "3.6.x",
+      "slug": "3.6",
+      "upcoming": true
+    },
+    {
+      "name": "3.5",
+      "branchName": "3.5.x",
+      "slug": "3.5",
+      "current": true
+    },
+    {
       "name": "3.4",
       "branchName": "3.4.x",
       "slug": "3.4",
-      "current": true
+      "maintained": false
     },
     {
       "name": "3.3",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -23,73 +23,61 @@
     },
     {
       "name": "3.4",
-      "branchName": "3.4.x",
       "slug": "3.4",
       "maintained": false
     },
     {
       "name": "3.3",
-      "branchName": "3.3.x",
       "slug": "3.3",
       "maintained": false
     },
     {
       "name": "3.2",
-      "branchName": "3.2.x",
       "slug": "3.2",
       "maintained": false
     },
     {
       "name": "3.1",
-      "branchName": "3.1.x",
       "slug": "3.1",
       "maintained": false
     },
     {
       "name": "3.0",
-      "branchName": "3.0.x",
       "slug": "3.0",
       "maintained": false
     },
     {
       "name": "2.2",
-      "branchName": "2.2.x",
       "slug": "2.2",
       "maintained": true
     },
     {
       "name": "2.1",
-      "branchName": "2.1.x",
       "slug": "2.1",
       "maintained": false
     },
     {
       "name": "2.0",
-      "branchName": "2.0.x",
       "slug": "2.0",
       "maintained": false
     },
     {
       "name": "1.3",
-      "branchName": "1.3",
       "slug": "1.3",
       "maintained": false
     },
     {
       "name": "1.2",
-      "branchName": "1.2",
       "slug": "1.2",
       "maintained": false
     },
     {
       "name": "1.1",
-      "branchName": "1.1",
       "slug": "1.1",
       "maintained": false
     },
     {
       "name": "1.0",
-      "branchName": "1.0",
       "slug": "1.0",
       "maintained": false
     }

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,4 +1,12 @@
-branches: ["3.0.x", "3.1.x", "3.2.x", "3.3.x", "3.4.x", "3.5.x", "4.0.x"]
-maintained_branches: ["3.5.x", "4.0.x"]
+branches:
+  - "3.0.x"
+  - "3.1.x"
+  - "3.2.x"
+  - "3.3.x"
+  - "3.4.x"
+  - "3.5.x"
+  - "3.6.x"
+  - "4.0.x"
+maintained_branches: ["3.5.x", "3.6.x", "4.0.x"]
 doc_dir: "docs/"
 dev_branch: "4.0.x"


### PR DESCRIPTION
3.5.0 has been released. As a consequence:

- 3.4.x is no longer maintained;
- 3.5.x is the new current branch;
- 3.6.x is the next minor branch.