### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -10,16 +10,22 @@
       "upcoming": true
     },
     {
+      "name": "3.7",
+      "branchName": "3.7.x",
+      "slug": "3.7",
+      "upcoming": true
+    },
+    {
       "name": "3.6",
       "branchName": "3.6.x",
       "slug": "3.6",
-      "upcoming": true
+      "current": true
     },
     {
       "name": "3.5",
       "branchName": "3.5.x",
       "slug": "3.5",
-      "current": true
+      "maintained": false
     },
     {
       "name": "3.4",

--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -55,7 +55,7 @@
     {
       "name": "2.2",
       "slug": "2.2",
-      "maintained": true
+      "maintained": false
     },
     {
       "name": "2.1",

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,12 +1,7 @@
 branches:
-  - "3.0.x"
-  - "3.1.x"
-  - "3.2.x"
-  - "3.3.x"
-  - "3.4.x"
-  - "3.5.x"
   - "3.6.x"
+  - "3.7.x"
   - "4.0.x"
-maintained_branches: ["3.5.x", "3.6.x", "4.0.x"]
+maintained_branches: ["3.6.x", "3.7.x", "4.0.x"]
 doc_dir: "docs/"
 dev_branch: "4.0.x"


### PR DESCRIPTION
3.6.0 has been released.

As a consequence:
- 3.5.x is no longer maintained;
- 3.6.x becomes the current branch;
- 3.7.x is the next minor branch.

Also, let's stop maintaining 2.x. Given how few downloads there are,
this should be fine.

<img width="828" height="377" alt="2025-11-07-205759_hyprshot" src="https://github.com/user-attachments/assets/42924471-c3cd-4f06-9791-ef353b57a955" />
