### PR TITLE
Add service migrations

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -6,6 +6,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener;
 use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ContainerAwareMigrationFactory;
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
+use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Configuration\Connection\ConnectionRegistryConnection;
 use Doctrine\Migrations\Configuration\Connection\ExistingConnection;
@@ -27,6 +29,7 @@ use Doctrine\Migrations\Tools\Console\Command\SyncMetadataCommand;
 use Doctrine\Migrations\Tools\Console\Command\UpToDateCommand;
 use Doctrine\Migrations\Tools\Console\Command\VersionCommand;
 use Doctrine\Migrations\Version\MigrationFactory;
+use Psr\Log\LoggerInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
@@ -63,6 +66,17 @@ return static function (ContainerConfigurator $container) {
                 service('doctrine.migrations.container_aware_migrations_factory.inner'),
                 service('service_container'),
             ])
+
+        ->set('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
+            ->args([
+                abstract_arg('migrations locator'),
+            ])
+
+        ->set('doctrine.migrations.connection', Connection::class)
+            ->factory([service('doctrine.migrations.dependency_factory'), 'getConnection'])
+
+        ->set('doctrine.migrations.logger', LoggerInterface::class)
+            ->factory([service('doctrine.migrations.dependency_factory'), 'getLogger'])
 
         ->set('doctrine_migrations.diff_command', DiffCommand::class)
             ->args([

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -42,9 +42,12 @@ application:
     # config/packages/doctrine_migrations.yaml
 
     doctrine_migrations:
+        # Whether to enable fetching migrations from the service container.
+        enable_service_migrations: false
+
         # List of namespace/path pairs to search for migrations, at least one required
         migrations_paths:
-            'App\Migrations': '%kernel.project_dir%/src/App'
+            'App\Migrations': '%kernel.project_dir%/src/Migrations'
             'AnotherApp\Migrations': '/path/to/other/migrations'
             'SomeBundle\Migrations': '@SomeBundle/Migrations'
 
@@ -234,11 +237,12 @@ Doctrine will then assume that this migration has already been run and will igno
 Migration Dependencies
 ----------------------
 
-Migrations can have dependencies on external services (such as geolocation, mailer, data processing services...) that
-can be used to have more powerful migrations. Those dependencies are not automatically injected into your migrations
-but need to be injected using custom migrations factories.
+Migrations can have dependencies on external services (such as geolocation, mailer or data processing services) to
+enable more advanced behavior. To inject dependencies into your migrations, you must enable loading migrations from
+the service container and register the migrations as services.
 
-Here is an example on how to inject the service container into your migrations:
+If you are using Symfony's default service configuration, migration services are registered automatically
+once placed in the ``src`` directory:
 
 .. configuration-block::
 
@@ -247,62 +251,71 @@ Here is an example on how to inject the service container into your migrations:
         # config/packages/doctrine_migrations.yaml
 
         doctrine_migrations:
-            services:
-                 'Doctrine\Migrations\Version\MigrationFactory': 'App\Migrations\Factory\MigrationFactoryDecorator'
+            enable_service_migrations: true
+            migrations_paths:
+                'App\Migrations': '%kernel.project_dir%/src/Migrations'
+
+
+If you are not using the default configuration, register your migration classes manually and make sure they are
+discoverable by the autoloader. If autoconfiguration is disabled, tag them manually with
+the ``doctrine_migrations.migration`` tag:
+
+.. configuration-block::
+
+    .. code-block:: yaml
 
         # config/services.yaml
 
         services:
-            App\Migrations\Factory\MigrationFactoryDecorator:
-                decorates: 'doctrine.migrations.migrations_factory'
-                arguments: ['@.inner', '@service_container']
+            DoctrineMigrations\Version20180605025653:
+                tags: [ 'doctrine_migrations.migration' ]
+                arguments:
+                    $myService: '@App\Services\MyService'
 
+
+The connection and logger services are injected automatically through bindings. You may specify them explicitly
+if needed:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # config/services.yaml
+
+        services:
+            DoctrineMigrations\Version20180605025653:
+                tags: [ 'doctrine_migrations.migration' ]
+                arguments:
+                    - '@doctrine.migrations.connection'
+                    - '@doctrine.migrations.logger'
+                    - '@App\Services\MyService'
+
+
+Then override the constructor in your migration class and add your dependencies:
 
 .. code-block:: php
 
     declare(strict_types=1);
 
-    namespace App\Migrations\Factory;
+    namespace App\Migrations;
 
+    use App\Services\MyService;
+    use Doctrine\DBAL\Schema\Schema;
     use Doctrine\Migrations\AbstractMigration;
-    use Doctrine\Migrations\Version\MigrationFactory;
-    use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-    use Symfony\Component\DependencyInjection\ContainerInterface;
 
-    class MigrationFactoryDecorator implements MigrationFactory
+    final class Version20180605025653 extends AbstractMigration
     {
-        private $migrationFactory;
-        private $container;
+        private MyService $myService;
 
-        public function __construct(MigrationFactory $migrationFactory, ContainerInterface $container)
+        public function __construct(Connection $connection, LoggerInterface $logger, MyService $myService)
         {
-            $this->migrationFactory = $migrationFactory;
-            $this->container        = $container;
+            parent::__construct($connection, $logger);
+
+            $this->myService = $myService;
         }
 
-        public function createVersion(string $migrationClassName): AbstractMigration
-        {
-            $instance = $this->migrationFactory->createVersion($migrationClassName);
-
-            if ($instance instanceof ContainerAwareInterface) {
-                $instance->setContainer($this->container);
-            }
-
-            return $instance;
-        }
+        // ...
     }
-
-
-.. tip::
-
-    If your migration class implements the interface ``Symfony\Component\DependencyInjection\ContainerAwareInterface``
-    this bundle will automatically inject the default symfony container into your migration class
-    (this because the ``MigrationFactoryDecorator`` shown in this example is the default migration factory used by this bundle).
-
-.. caution::
-
-    The interface ``Symfony\Component\DependencyInjection\ContainerAwareInterface`` has been deprecated in Symfony 6.4 and
-    removed in 7.0. If you use this version or newer, there is currently no way to inject the service container into migrations.
 
 
 Generating Migrations Automatically

--- a/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
+++ b/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass;
+
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+/** @internal */
+final class RegisterMigrationsPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        if (! $container->hasDefinition('doctrine.migrations.service_migrations_repository')) {
+            return;
+        }
+
+        $migrationRefs = [];
+
+        foreach ($container->findTaggedServiceIds('doctrine_migrations.migration', true) as $id => $attributes) {
+            $definition = $container->getDefinition($id);
+            $definition->setBindings([
+                Connection::class => new BoundArgument(new Reference('doctrine.migrations.connection'), false),
+                LoggerInterface::class => new BoundArgument(new Reference('doctrine.migrations.logger'), false),
+            ]);
+
+            $migrationRefs[$id] = new TypedReference($id, $definition->getClass());
+        }
+
+        $container->getDefinition('doctrine.migrations.service_migrations_repository')
+            ->replaceArgument(0, new ServiceLocatorArgument($migrationRefs));
+    }
+}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,6 +34,11 @@ class Configuration implements ConfigurationInterface
             ->fixXmlConfig('migration', 'migrations')
             ->fixXmlConfig('migrations_path', 'migrations_paths')
             ->children()
+                ->booleanNode('enable_service_migrations')
+                    ->info('Whether to enable fetching migrations from the service container.')
+                    ->defaultFalse()
+                ->end()
+
                 ->arrayNode('migrations_paths')
                     ->info('A list of namespace/path pairs where to look for migrations.')
                     ->defaultValue([])

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -6,8 +6,10 @@ namespace Doctrine\Bundle\MigrationsBundle\DependencyInjection;
 
 use Doctrine\Bundle\MigrationsBundle\Collector\MigrationsCollector;
 use Doctrine\Bundle\MigrationsBundle\Collector\MigrationsFlattener;
+use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\MigrationFactory;
 use InvalidArgumentException;
 use RuntimeException;
@@ -48,6 +50,19 @@ class DoctrineMigrationsExtension extends Extension
         $loader  = new PhpFileLoader($container, $locator);
 
         $loader->load('services.php');
+
+        if ($config['enable_service_migrations']) {
+            $container->registerForAutoconfiguration(AbstractMigration::class)
+                ->addTag('doctrine_migrations.migration');
+
+            if (! isset($config['services'][MigrationsRepository::class])) {
+                $config['services'][MigrationsRepository::class] = 'doctrine.migrations.service_migrations_repository';
+            }
+        } else {
+            $container->removeDefinition('doctrine.migrations.service_migrations_repository');
+            $container->removeDefinition('doctrine.migrations.connection');
+            $container->removeDefinition('doctrine.migrations.logger');
+        }
 
         $configurationDefinition = $container->getDefinition('doctrine.migrations.configuration');
 

--- a/src/DoctrineMigrationsBundle.php
+++ b/src/DoctrineMigrationsBundle.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle;
 
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\ConfigureDependencyFactoryPass;
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -16,6 +17,7 @@ class DoctrineMigrationsBundle extends Bundle
     public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new ConfigureDependencyFactoryPass());
+        $container->addCompilerPass(new RegisterMigrationsPass());
     }
 
     public function getPath(): string

--- a/src/MigrationsRepository/ServiceMigrationsRepository.php
+++ b/src/MigrationsRepository/ServiceMigrationsRepository.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
+use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Version\Version;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/** @internal */
+final class ServiceMigrationsRepository implements MigrationsRepository
+{
+    /** @var ServiceProviderInterface<AbstractMigration> */
+    private $container;
+
+    /** @var array<string, AvailableMigration> */
+    private $migrations = [];
+
+    /** @param ServiceProviderInterface<AbstractMigration> $container */
+    public function __construct(ServiceProviderInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    public function hasMigration(string $version): bool
+    {
+        return isset($this->migrations[$version]) || $this->container->has($version);
+    }
+
+    public function getMigration(Version $version): AvailableMigration
+    {
+        $this->loadMigrationFromContainer($version);
+
+        return $this->migrations[(string) $version];
+    }
+
+    /**
+     * Returns a non-sorted set of migrations.
+     */
+    public function getMigrations(): AvailableMigrationsSet
+    {
+        foreach ($this->container->getProvidedServices() as $id) {
+            $this->loadMigrationFromContainer(new Version($id));
+        }
+
+        return new AvailableMigrationsSet($this->migrations);
+    }
+
+    private function loadMigrationFromContainer(Version $version): void
+    {
+        $id = (string) $version;
+
+        if (isset($this->migrations[$id])) {
+            return;
+        }
+
+        if (! $this->container->has($id)) {
+            throw MigrationClassNotFound::new($id);
+        }
+
+        $this->migrations[$id] = new AvailableMigration($version, $this->container->get($id));
+    }
+}

--- a/tests/DependencyInjection/CompilerPass/RegisterMigrationsPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/RegisterMigrationsPassTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection\CompilerPass;
+
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\Migration001;
+use Doctrine\DBAL\Connection;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
+use Symfony\Component\DependencyInjection\Argument\BoundArgument;
+use Symfony\Component\DependencyInjection\Argument\ServiceLocatorArgument;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\TypedReference;
+
+class RegisterMigrationsPassTest extends TestCase
+{
+    public function testProcessWhenServiceMigrationsRepositoryIsRegistered(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
+            ->addArgument(new AbstractArgument());
+        $container->register(Migration001::class, Migration001::class)->addTag('doctrine_migrations.migration');
+
+        $pass = new RegisterMigrationsPass();
+        $pass->process($container);
+
+        $argument = $container->getDefinition('doctrine.migrations.service_migrations_repository')->getArgument(0);
+        self::assertEquals(
+            new ServiceLocatorArgument([Migration001::class => new TypedReference(Migration001::class, Migration001::class)]),
+            $argument
+        );
+
+        self::assertEquals([
+            Connection::class => new BoundArgument(new Reference('doctrine.migrations.connection'), false),
+            LoggerInterface::class => new BoundArgument(new Reference('doctrine.migrations.logger'), false),
+        ], $container->getDefinition(Migration001::class)->getBindings());
+    }
+
+    public function testProcessWhenServiceMigrationsRepositoryIsNotRegistered(): void
+    {
+        $container = new ContainerBuilder();
+
+        $pass = new RegisterMigrationsPass();
+        $pass->process($container);
+
+        self::assertFalse($container->hasDefinition('doctrine.migrations.service_migrations_repository'));
+    }
+}

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -9,15 +9,19 @@ use Composer\Semver\VersionParser;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\Compiler\CacheCompatibilityPass;
 use Doctrine\Bundle\DoctrineBundle\DependencyInjection\DoctrineExtension;
 use Doctrine\Bundle\DoctrineBundle\Registry;
+use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
 use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ContainerAwareMigration;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ServiceMigration001;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services\FooService;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\TestBundle\TestBundle;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Exception\MissingDependency;
 use Doctrine\Migrations\Metadata\Storage\MetadataStorage;
 use Doctrine\Migrations\Metadata\Storage\TableMetadataStorageConfiguration;
+use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\Comparator;
 use Doctrine\Migrations\Version\Version;
 use Exception;
@@ -28,6 +32,7 @@ use Symfony\Bridge\PhpUnit\ExpectDeprecationTrait;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\Alias;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -467,6 +472,65 @@ class DoctrineMigrationsExtensionTest extends TestCase
         assert($config instanceof Configuration);
 
         self::assertFalse($config->isTransactional());
+    }
+
+    public function testEnableServiceMigrationsWhenSetToTrue(): void
+    {
+        $config    = ['enable_service_migrations' => true];
+        $container = $this->getContainer($config);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->addCompilerPass(new RegisterMigrationsPass());
+
+        $container->register('foo', FooService::class);
+        $container->register(ServiceMigration001::class)
+            ->setPublic(true)
+            ->setAutoconfigured(true)
+            ->setArgument('$fooService', new Reference('foo'));
+        $container->compile();
+
+        $migration = $container->getDefinition(ServiceMigration001::class);
+        self::assertTrue($migration->hasTag('doctrine_migrations.migration'));
+        self::assertEquals([
+            new Reference('doctrine.migrations.connection'),
+            new Reference('foo'),
+            new Reference('doctrine.migrations.logger'),
+        ], $migration->getArguments());
+        self::assertInstanceOf(ServiceMigration001::class, $container->get(ServiceMigration001::class));
+
+        self::assertContainsEquals(
+            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.service_migrations_repository'))]],
+            $container->getDefinition('doctrine.migrations.dependency_factory')->getMethodCalls()
+        );
+
+        self::assertTrue($container->has('doctrine.migrations.service_migrations_repository'));
+        self::assertTrue($container->has('doctrine.migrations.connection'));
+        self::assertTrue($container->has('doctrine.migrations.logger'));
+    }
+
+    public function testEnableServiceMigrationsWhenSetToFalse(): void
+    {
+        $config    = ['enable_service_migrations' => false];
+        $container = $this->getContainer($config);
+        $container->getCompilerPassConfig()->setRemovingPasses([]);
+        $container->addCompilerPass(new RegisterMigrationsPass());
+
+        $container->register('foo', FooService::class);
+        $container->register(ServiceMigration001::class)
+            ->setPublic(true)
+            ->setAutoconfigured(true)
+            ->setArgument('$fooService', new Reference('foo'));
+        $container->compile();
+
+        self::assertFalse($container->getDefinition(ServiceMigration001::class)->hasTag('doctrine_migrations.migration'));
+
+        self::assertNotContainsEquals(
+            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.service_migrations_repository'))]],
+            $container->getDefinition('doctrine.migrations.dependency_factory')->getMethodCalls()
+        );
+
+        self::assertFalse($container->has('doctrine.migrations.service_migrations_repository'));
+        self::assertFalse($container->has('doctrine.migrations.connection'));
+        self::assertFalse($container->has('doctrine.migrations.logger'));
     }
 
     /**

--- a/tests/Fixtures/Migrations/ServiceMigration001.php
+++ b/tests/Fixtures/Migrations/ServiceMigration001.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations;
+
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services\FooService;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Psr\Log\LoggerInterface;
+
+class ServiceMigration001 extends AbstractMigration
+{
+    /** @var FooService */
+    public $fooService;
+
+    public function __construct(Connection $connection, FooService $fooService, LoggerInterface $logger)
+    {
+        parent::__construct($connection, $logger);
+
+        $this->fooService = $fooService;
+    }
+
+    public function up(Schema $schema): void
+    {
+        // TODO: Implement up() method.
+    }
+}

--- a/tests/Fixtures/Services/FooService.php
+++ b/tests/Fixtures/Services/FooService.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services;
+
+class FooService
+{
+}

--- a/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
+++ b/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsRepository;
+
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Version\Version;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class ServiceMigrationsRepositoryTest extends TestCase
+{
+    /**
+     * @testWith [true]
+     *           [false]
+     */
+    public function testHasMigration(bool $expectedResult): void
+    {
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn($expectedResult);
+
+        $repository = new ServiceMigrationsRepository($container);
+
+        self::assertSame($expectedResult, $repository->hasMigration('Version001'));
+    }
+
+    public function testGetMigrationReturnsAvailableMigration(): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn(true);
+        $container->method('get')
+            ->with('Version001')
+            ->willReturn($migration);
+
+        $repository = new ServiceMigrationsRepository($container);
+        $version    = new Version('Version001');
+
+        $availableMigration = $repository->getMigration($version);
+
+        self::assertSame($version, $availableMigration->getVersion());
+        self::assertSame($migration, $availableMigration->getMigration());
+    }
+
+    public function testGetMigrationThrowsExceptionWhenMigrationNotFound(): void
+    {
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('NonExistentVersion')
+            ->willReturn(false);
+
+        $repository = new ServiceMigrationsRepository($container);
+        $version    = new Version('NonExistentVersion');
+
+        $this->expectException(MigrationClassNotFound::class);
+
+        $repository->getMigration($version);
+    }
+
+    public function testGetMigrationsReturnsAvailableMigrationsSet(): void
+    {
+        $migration1 = $this->createMock(AbstractMigration::class);
+        $migration2 = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('getProvidedServices')
+            ->willReturn(['Version001', 'Version002']);
+        $container->method('has')
+            ->willReturn(true);
+        $container->method('get')
+            ->willReturnMap([
+                ['Version001', $migration1],
+                ['Version002', $migration2],
+            ]);
+
+        $repository = new ServiceMigrationsRepository($container);
+
+        $migrationsSet = $repository->getMigrations();
+
+        self::assertCount(2, $migrationsSet->getItems());
+    }
+}


### PR DESCRIPTION
A continuation of #524.

Unlike the previous PR, which attempted to support both migrations as services and regular migrations, this one introduces a new `enable_service_migrations` option, which greatly simplifies the overall implementation.

When enabled, Doctrine will fetch migrations from Symfony’s service container.

To use migrations as services, they need to be autoloadable. IMO, the best approach is to place them inside your `src` directory, for example:

```diff
doctrine_migrations:
+   enable_service_migrations: true
    migrations_paths:
-       'DoctrineMigrations': '%kernel.project_dir%/migrations'
+       'App\Migrations': '%kernel.project_dir%/src/Migrations'
```