### PR TITLE
Add required return types to MigrationsCollector for Symfony 8 compatibility

### DIFF
--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -31,7 +31,7 @@ class MigrationsCollector extends DataCollector
     }
 
     /** @return void */
-    public function collect(Request $request, Response $response, ?Throwable $exception = null)
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         if ($this->data !== []) {
             return;

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -88,8 +88,7 @@ class MigrationsCollector extends DataCollector
         return $this->data;
     }
 
-    /** @return void */
-    public function reset()
+    public function reset(): void
     {
         $this->data = [];
     }

--- a/src/Collector/MigrationsCollector.php
+++ b/src/Collector/MigrationsCollector.php
@@ -77,7 +77,7 @@ class MigrationsCollector extends DataCollector
     }
 
     /** @return string */
-    public function getName()
+    public function getName(): string
     {
         return 'doctrine_migrations';
     }


### PR DESCRIPTION
Method signatures in `MigrationsCollector` require updating to be compatible with base classes and interfaces in Symfony 8.

 - add `void` return type to `MigrationsCollector::collect()`
 - add `void` return type to `MigrationsCollector::reset()`
 - add `string` return type to `MigrationsCollector::getName()`

The `string` and `void` return types were added in PHP 7.0 and 7.1, respectively. As the latest version of this package supports a minimum PHP version of 7.2 I see no backwards compatibility issues or breaking changes.

I'm looking to merge this into `3.7.x` purely to allow for the soonest possible release. Please adjust if this is not what I should be doing.