### PR TITLE
Removed ContainerAwareMigrationFactory usage

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener;
-use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ContainerAwareMigrationFactory;
 use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
@@ -59,13 +58,6 @@ return static function (ContainerConfigurator $container) {
 
         ->set('doctrine.migrations.migrations_factory', MigrationFactory::class)
             ->factory([service('doctrine.migrations.dependency_factory'), 'getMigrationFactory'])
-
-        ->set('doctrine.migrations.container_aware_migrations_factory', ContainerAwareMigrationFactory::class)
-            ->decorate('doctrine.migrations.migrations_factory')
-            ->args([
-                service('doctrine.migrations.container_aware_migrations_factory.inner'),
-                service('service_container'),
-            ])
 
         ->set('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
             ->args([


### PR DESCRIPTION
Fixes #638 

## Summary
In SF8 project that uses this bundle, I had an error:

> Attempted to load class "ContainerAwareMigrationFactory" from namespace "Doctrine\Bundle\MigrationsBundle\MigrationsFactory". Did you forget a "use" statement for another namespace? (500 Internal Server Error)

## Explanation
If I understand correctly, this class disappeared in commit d90e9f0c0951cf803e53a448ad44a2f23888e8eb ("Remove support for container-aware migrations (#574)", january), but references were back in commit 5eb080a96af1937d0fefbb92ef43d03c32a2d706 ("Migrate service config from XML to PHP", october). So I think it's an error, when convertir config?

This PR aims to fix that.