### PR TITLE
Fix build

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,18 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^7.2 || ^8.0",
+        "doctrine/dbal": "^2 || ^3 || ^4",
         "doctrine/doctrine-bundle": "^2.4 || ^3.0",
         "doctrine/migrations": "^3.2",
+        "psr/log": "^1 || ^2 || ^3",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0"
+        "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "composer/semver": "^3.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,6 @@
 parameters:
     level: 7
-    phpVersion: 80400
+    phpVersion: 80500
     paths:
         - src
         - tests


### PR DESCRIPTION
A lot of the dependencies we use in the code were not declared.

Since the library requires `doctrine/dbal`, it should be fine to require
it in the bundle as well.

Since this is a bundle, it should be fine to require Symfony components.

Since `psr/log` is very widely used, it should be fine to require it.

Note that `symfony/http-kernel` 8 is not allowed yet, because this bundle is
not compatible with it yet.