### PR TITLE
Avoid deprecated AbstractAsset::getName() call

### DIFF
--- a/src/EventListener/SchemaFilterListener.php
+++ b/src/EventListener/SchemaFilterListener.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\EventListener;
 
 use Doctrine\DBAL\Schema\AbstractAsset;
+use Doctrine\DBAL\Schema\AbstractNamedObject;
 use Doctrine\DBAL\Schema\Name\OptionallyQualifiedName;
 use Doctrine\ORM\Tools\Console\Command\SchemaTool\UpdateCommand;
 use Doctrine\ORM\Tools\Console\Command\ValidateSchemaCommand;
@@ -28,7 +29,7 @@ final class SchemaFilterListener
     /** @var bool */
     private $enabled = false;
 
-    /** @param AbstractAsset<OptionallyQualifiedName>|string $asset */
+    /** @param AbstractAsset<OptionallyQualifiedName>|AbstractNamedObject<OptionallyQualifiedName>|string $asset */
     public function __invoke($asset): bool
     {
         if (! $this->enabled) {
@@ -36,7 +37,9 @@ final class SchemaFilterListener
         }
 
         if ($asset instanceof AbstractAsset) {
-            $asset = $asset->getName();
+            $asset = $asset instanceof AbstractNamedObject
+                ? $asset->getObjectName()->toString()
+                : $asset->getName();
         }
 
         return $asset !== $this->configurationTableName;


### PR DESCRIPTION
## Summary

In DBAL 4.4+, `AbstractAsset::getName()` is deprecated (see [doctrine/dbal#7094](https://github.com/doctrine/dbal/pull/7094)).

This PR updates `SchemaFilterListener` to use `getObjectName()->toString()` when available (for `AbstractNamedObject` instances), with a fallback to `getName()` for other asset types.

---

This is my first PR on the project, hope I did everything right!