### PR TITLE
Drop support for old versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,18 +25,18 @@
     "homepage": "https://www.doctrine-project.org",
     "require": {
         "php": "^8.4",
-        "doctrine/dbal": "^2 || ^3 || ^4",
+        "doctrine/dbal": "^4",
         "doctrine/doctrine-bundle": "^3",
         "doctrine/migrations": "^3.2",
-        "psr/log": "^1 || ^2 || ^3",
+        "psr/log": "^3",
         "symfony/config": "^6.4 || ^7.0 || ^8.0",
         "symfony/console": "^6.4 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
-        "symfony/deprecation-contracts": "^2.1 || ^3",
+        "symfony/deprecation-contracts": "^3",
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
         "symfony/http-foundation": "^6.4 || ^7.0 || ^8.0",
         "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0",
-        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
+        "symfony/service-contracts": "^3.0"
     },
     "require-dev": {
         "composer/semver": "^3.0",
@@ -47,7 +47,7 @@
         "phpstan/phpstan-phpunit": "^2",
         "phpstan/phpstan-strict-rules": "^2",
         "phpstan/phpstan-symfony": "^2",
-        "phpunit/phpunit": "^10.5.58 || ^11.5",
+        "phpunit/phpunit": "^11.5.45",
         "symfony/var-exporter": "^6.4 || ^7 || ^8"
     },
     "autoload": {


### PR DESCRIPTION
Let us still retain compatibility with Symfony 6.4.