### PR TITLE
Stop using deprecated option

### DIFF
--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -326,7 +326,6 @@ class DoctrineMigrationsExtensionTest extends TestCase
                     'custom' => null,
                     'acb' => null,
                 ],
-                'controller_resolver' => ['auto_mapping' => false],
             ],
         );
 


### PR DESCRIPTION
Since `doctrine/doctrine-bundle` 3.1, `auto_mapping` is deprecated and only accepts false.