### PR TITLE
Update branch metadata

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -4,10 +4,22 @@
   "slug": "doctrine-migrations-bundle",
   "versions": [
     {
+      "name": "5.0",
+      "branchName": "5.0.x",
+      "slug": "5.0",
+      "upcoming": true
+    },
+    {
+      "name": "4.1",
+      "branchName": "4.1.x",
+      "slug": "4.1",
+      "upcoming": true
+    },
+    {
       "name": "4.0",
       "branchName": "4.0.x",
       "slug": "4.0",
-      "upcoming": true
+      "current": true
     },
     {
       "name": "3.8",
@@ -19,32 +31,7 @@
       "name": "3.7",
       "branchName": "3.7.x",
       "slug": "3.7",
-      "current": true
-    },
-    {
-      "name": "3.6",
-      "slug": "3.6",
-      "maintained": false
-    },
-    {
-      "name": "3.5",
-      "slug": "3.5",
-      "maintained": false
-    },
-    {
-      "name": "3.4",
-      "slug": "3.4",
-      "maintained": false
-    },
-    {
-      "name": "3.3",
-      "slug": "3.3",
-      "maintained": false
-    },
-    {
-      "name": "3.2",
-      "slug": "3.2",
-      "maintained": false
+      "maintained": true
     }
   ]
 }

--- a/.symfony.bundle.yaml
+++ b/.symfony.bundle.yaml
@@ -1,12 +1,9 @@
 branches:
-  - "3.2.x"
-  - "3.3.x"
-  - "3.4.x"
-  - "3.5.x"
-  - "3.6.x"
   - "3.7.x"
   - "3.8.x"
   - "4.0.x"
-maintained_branches: ["3.7.x", "3.8.x", "4.0.x"]
+  - "4.1.x"
+  - "5.0.x"
+maintained_branches: ["3.7.x", "3.8.x", "4.0.x", "4.1.x", "5.0.x"]
 doc_dir: "docs/"
-dev_branch: "4.0.x"
+dev_branch: "5.0.x"


### PR DESCRIPTION
4.0.0 has been released. As a consequence:

- 3.7.x is just maintained;
- 4.0.x is the new current branch;
- 4.1.x and 5.0.x have been created, and are upcoming.

I have also taken this as an occasion to remove old doc versions.