### PR TITLE
[Documentation] Remove annotations from documentation

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -351,32 +351,6 @@ for Doctrine's ORM:
             #[ORM\Column(type: Types::STRING, length: 255)]
             private $name;
 
-    .. code-block:: php-annotations
-
-        // src/Entity/User.php
-
-        namespace App\Entity;
-
-        use Doctrine\ORM\Mapping as ORM;
-
-        /**
-         * @ORM\Entity
-         * @ORM\Table(name="hello_user")
-         */
-        class User
-        {
-            /**
-             * @ORM\Id
-             * @ORM\Column(type="integer")
-             * @ORM\GeneratedValue(strategy="AUTO")
-             */
-            private $id;
-
-            /**
-             * @ORM\Column(type="string", length=255)
-             */
-            private $name;
-
     .. code-block:: yaml
 
         # config/doctrine/User.orm.yaml


### PR DESCRIPTION
IIUC from `composer.json` file, with 4.0.x it's no longer possible to use a version of `doctrine/orm` allowing annotations to define mapping. 
I think we can safely remove this example from doc