### PR TITLE
[Documentation] Remove version from installation command

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,7 @@ Run this command in your terminal:
 
 .. code-block:: terminal
 
-    $ composer require doctrine/doctrine-migrations-bundle "^3.0"
+    $ composer require doctrine/doctrine-migrations-bundle
 
 If you don't use `Symfony Flex`_, you must enable the bundle manually in the application:
 


### PR DESCRIPTION
Documentation for [current version](https://symfony.com/bundles/DoctrineMigrationsBundle/current/index.html#installation) indicate to run `composer require doctrine/doctrine-migrations-bundle "^3.0"` to install this package

I think it is possible to remove this version restriction from documentation