### PR TITLE
Change target branch for Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "weekly"
     labels:
       - "CI"
+    target-branch: "3.7.x"
     groups:
       doctrine:
         patterns:


### PR DESCRIPTION
We are in a transition period during which the default branch and the lowest supported branch are not the same.