### PR TITLE
Load the configured migration paths when service migrations are enabled

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -15,6 +15,7 @@ use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
 use Doctrine\Migrations\Configuration\EntityManager\ManagerRegistryEntityManager;
 use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
 use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\Tools\Console\Command\CurrentCommand;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand;
@@ -70,7 +71,13 @@ return static function (ContainerConfigurator $container) {
         ->set('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
             ->args([
                 abstract_arg('migrations locator'),
+                service('doctrine.migrations.configuration'),
+                service('doctrine.migrations.migrations_finder'),
+                service('doctrine.migrations.migrations_factory'),
             ])
+
+        ->set('doctrine.migrations.migrations_finder', MigrationFinder::class)
+            ->factory([service('doctrine.migrations.dependency_factory'), 'getMigrationsFinder'])
 
         ->set('doctrine.migrations.connection', Connection::class)
             ->factory([service('doctrine.migrations.dependency_factory'), 'getConnection'])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -256,6 +256,9 @@ once placed in the ``src`` directory:
                 'App\Migrations': '%kernel.project_dir%/src/Migrations'
 
 
+Migrations which are not registered as services, such as the ones shipped by third party bundles in their own
+``migrations_paths``, are still loaded from the configured paths.
+
 If you are not using the default configuration, register your migration classes manually and make sure they are
 discoverable by the autoloader. If autoconfiguration is disabled, tag them manually with
 the ``doctrine_migrations.migration`` tag:

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -60,6 +60,7 @@ class DoctrineMigrationsExtension extends Extension
             }
         } else {
             $container->removeDefinition('doctrine.migrations.service_migrations_repository');
+            $container->removeDefinition('doctrine.migrations.migrations_finder');
             $container->removeDefinition('doctrine.migrations.connection');
             $container->removeDefinition('doctrine.migrations.logger');
         }

--- a/src/MigrationsRepository/ServiceMigrationFactory.php
+++ b/src/MigrationsRepository/ServiceMigrationFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/**
+ * Returns the migrations registered as services from the container, and lets the decorated
+ * factory instantiate the other ones (e.g. the migrations shipped by third party bundles).
+ *
+ * @internal
+ */
+final class ServiceMigrationFactory implements MigrationFactory
+{
+    /** @var ServiceProviderInterface<AbstractMigration> */
+    private $container;
+
+    /** @var MigrationFactory */
+    private $migrationFactory;
+
+    /** @param ServiceProviderInterface<AbstractMigration> $container */
+    public function __construct(ServiceProviderInterface $container, MigrationFactory $migrationFactory)
+    {
+        $this->container        = $container;
+        $this->migrationFactory = $migrationFactory;
+    }
+
+    public function createVersion(string $migrationClassName): AbstractMigration
+    {
+        if ($this->container->has($migrationClassName)) {
+            return $this->container->get($migrationClassName);
+        }
+
+        return $this->migrationFactory->createVersion($migrationClassName);
+    }
+}

--- a/src/MigrationsRepository/ServiceMigrationsRepository.php
+++ b/src/MigrationsRepository/ServiceMigrationsRepository.php
@@ -7,6 +7,7 @@ namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\FilesystemMigrationsRepository;
 use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
@@ -16,12 +17,12 @@ use Doctrine\Migrations\Version\Version;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 use function array_keys;
-use function array_merge;
-use function class_exists;
 
 /**
- * Loads the migrations registered as services and falls back to the configured migration classes and
- * directories for the other ones (e.g. the migrations shipped by third party bundles).
+ * Loads the migrations registered as services and delegates to the default repository of
+ * doctrine/migrations for the configured migration classes and directories, so that the
+ * migrations which are not registered as services (e.g. the ones shipped by third party bundles)
+ * are available as well.
  *
  * @internal
  */
@@ -39,11 +40,11 @@ final class ServiceMigrationsRepository implements MigrationsRepository
     /** @var MigrationFactory|null */
     private $migrationFactory;
 
+    /** @var MigrationsRepository|null */
+    private $configuredMigrationsRepository;
+
     /** @var array<string, AvailableMigration> */
     private $migrations = [];
-
-    /** @var bool */
-    private $filesystemMigrationsLoaded = false;
 
     /** @param ServiceProviderInterface<AbstractMigration> $container */
     public function __construct(
@@ -64,16 +65,26 @@ final class ServiceMigrationsRepository implements MigrationsRepository
             return true;
         }
 
-        $this->loadMigrationsFromFilesystem();
+        $repository = $this->getConfiguredMigrationsRepository();
 
-        return isset($this->migrations[$version]);
+        return $repository !== null && $repository->hasMigration($version);
     }
 
     public function getMigration(Version $version): AvailableMigration
     {
-        $this->loadMigrationFromContainer($version);
+        $migration = $this->loadMigrationFromContainer($version);
 
-        return $this->migrations[(string) $version];
+        if ($migration !== null) {
+            return $migration;
+        }
+
+        $repository = $this->getConfiguredMigrationsRepository();
+
+        if ($repository === null) {
+            throw MigrationClassNotFound::new((string) $version);
+        }
+
+        return $repository->getMigration($version);
     }
 
     /**
@@ -85,67 +96,53 @@ final class ServiceMigrationsRepository implements MigrationsRepository
             $this->loadMigrationFromContainer(new Version($id));
         }
 
-        $this->loadMigrationsFromFilesystem();
+        $migrations = $this->migrations;
+        $repository = $this->getConfiguredMigrationsRepository();
 
-        return new AvailableMigrationsSet($this->migrations);
+        if ($repository !== null) {
+            foreach ($repository->getMigrations()->getItems() as $migration) {
+                $migrations[(string) $migration->getVersion()] = $migrations[(string) $migration->getVersion()] ?? $migration;
+            }
+        }
+
+        return new AvailableMigrationsSet($migrations);
     }
 
-    private function loadMigrationFromContainer(Version $version): void
+    private function loadMigrationFromContainer(Version $version): ?AvailableMigration
     {
         $id = (string) $version;
 
         if (isset($this->migrations[$id])) {
-            return;
+            return $this->migrations[$id];
         }
 
         if (! $this->container->has($id)) {
-            $this->loadMigrationsFromFilesystem();
-
-            if (isset($this->migrations[$id])) {
-                return;
-            }
-
-            throw MigrationClassNotFound::new($id);
+            return null;
         }
 
-        $this->migrations[$id] = new AvailableMigration($version, $this->container->get($id));
+        return $this->migrations[$id] = new AvailableMigration($version, $this->container->get($id));
     }
 
     /**
-     * Registers the migrations found in the configured classes and directories which are not
-     * registered as services, the way the default repository of doctrine/migrations does.
+     * The repository of doctrine/migrations for the configured migration classes and directories,
+     * resolving the migrations registered as services from the container instead of instantiating
+     * them a second time.
      */
-    private function loadMigrationsFromFilesystem(): void
+    private function getConfiguredMigrationsRepository(): ?MigrationsRepository
     {
-        if ($this->filesystemMigrationsLoaded) {
-            return;
+        if ($this->configuredMigrationsRepository !== null) {
+            return $this->configuredMigrationsRepository;
         }
-
-        $this->filesystemMigrationsLoaded = true;
 
         if ($this->configuration === null || $this->migrationFinder === null || $this->migrationFactory === null) {
-            return;
+            return null;
         }
 
-        $classes = $this->configuration->getMigrationClasses();
-
-        foreach ($this->configuration->getMigrationDirectories() as $namespace => $path) {
-            $classes = array_merge($classes, $this->migrationFinder->findMigrations($path, $namespace));
-        }
-
-        foreach ($classes as $class) {
-            if (isset($this->migrations[$class]) || $this->container->has($class)) {
-                continue;
-            }
-
-            if (! class_exists($class)) {
-                throw MigrationClassNotFound::new($class);
-            }
-
-            $this->migrations[$class] = new AvailableMigration(
-                new Version($class),
-                $this->migrationFactory->createVersion($class)
-            );
-        }
+        return $this->configuredMigrationsRepository = new FilesystemMigrationsRepository(
+            $this->configuration->getMigrationClasses(),
+            $this->configuration->getMigrationDirectories(),
+            $this->migrationFinder,
+            new ServiceMigrationFactory($this->container, $this->migrationFactory)
+        );
     }
 }

--- a/src/MigrationsRepository/ServiceMigrationsRepository.php
+++ b/src/MigrationsRepository/ServiceMigrationsRepository.php
@@ -5,31 +5,68 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
 
 use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Finder\MigrationFinder;
 use Doctrine\Migrations\Metadata\AvailableMigration;
 use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
 use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
-/** @internal */
+use function array_keys;
+use function array_merge;
+use function class_exists;
+
+/**
+ * Loads the migrations registered as services and falls back to the configured migration classes and
+ * directories for the other ones (e.g. the migrations shipped by third party bundles).
+ *
+ * @internal
+ */
 final class ServiceMigrationsRepository implements MigrationsRepository
 {
     /** @var ServiceProviderInterface<AbstractMigration> */
     private $container;
 
+    /** @var Configuration|null */
+    private $configuration;
+
+    /** @var MigrationFinder|null */
+    private $migrationFinder;
+
+    /** @var MigrationFactory|null */
+    private $migrationFactory;
+
     /** @var array<string, AvailableMigration> */
     private $migrations = [];
 
+    /** @var bool */
+    private $filesystemMigrationsLoaded = false;
+
     /** @param ServiceProviderInterface<AbstractMigration> $container */
-    public function __construct(ServiceProviderInterface $container)
-    {
-        $this->container = $container;
+    public function __construct(
+        ServiceProviderInterface $container,
+        ?Configuration $configuration = null,
+        ?MigrationFinder $migrationFinder = null,
+        ?MigrationFactory $migrationFactory = null
+    ) {
+        $this->container        = $container;
+        $this->configuration    = $configuration;
+        $this->migrationFinder  = $migrationFinder;
+        $this->migrationFactory = $migrationFactory;
     }
 
     public function hasMigration(string $version): bool
     {
-        return isset($this->migrations[$version]) || $this->container->has($version);
+        if (isset($this->migrations[$version]) || $this->container->has($version)) {
+            return true;
+        }
+
+        $this->loadMigrationsFromFilesystem();
+
+        return isset($this->migrations[$version]);
     }
 
     public function getMigration(Version $version): AvailableMigration
@@ -44,9 +81,11 @@ final class ServiceMigrationsRepository implements MigrationsRepository
      */
     public function getMigrations(): AvailableMigrationsSet
     {
-        foreach ($this->container->getProvidedServices() as $id) {
+        foreach (array_keys($this->container->getProvidedServices()) as $id) {
             $this->loadMigrationFromContainer(new Version($id));
         }
+
+        $this->loadMigrationsFromFilesystem();
 
         return new AvailableMigrationsSet($this->migrations);
     }
@@ -60,9 +99,53 @@ final class ServiceMigrationsRepository implements MigrationsRepository
         }
 
         if (! $this->container->has($id)) {
+            $this->loadMigrationsFromFilesystem();
+
+            if (isset($this->migrations[$id])) {
+                return;
+            }
+
             throw MigrationClassNotFound::new($id);
         }
 
         $this->migrations[$id] = new AvailableMigration($version, $this->container->get($id));
+    }
+
+    /**
+     * Registers the migrations found in the configured classes and directories which are not
+     * registered as services, the way the default repository of doctrine/migrations does.
+     */
+    private function loadMigrationsFromFilesystem(): void
+    {
+        if ($this->filesystemMigrationsLoaded) {
+            return;
+        }
+
+        $this->filesystemMigrationsLoaded = true;
+
+        if ($this->configuration === null || $this->migrationFinder === null || $this->migrationFactory === null) {
+            return;
+        }
+
+        $classes = $this->configuration->getMigrationClasses();
+
+        foreach ($this->configuration->getMigrationDirectories() as $namespace => $path) {
+            $classes = array_merge($classes, $this->migrationFinder->findMigrations($path, $namespace));
+        }
+
+        foreach ($classes as $class) {
+            if (isset($this->migrations[$class]) || $this->container->has($class)) {
+                continue;
+            }
+
+            if (! class_exists($class)) {
+                throw MigrationClassNotFound::new($class);
+            }
+
+            $this->migrations[$class] = new AvailableMigration(
+                new Version($class),
+                $this->migrationFactory->createVersion($class)
+            );
+        }
     }
 }

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -13,10 +13,12 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
 use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ContainerAwareMigration;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ServiceMigration001;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services\FooService;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\TestBundle\TestBundle;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\ThirdPartyMigrations\Version20240101000000;
 use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\DependencyFactory;
 use Doctrine\Migrations\Exception\MissingDependency;
@@ -479,8 +481,48 @@ class DoctrineMigrationsExtensionTest extends TestCase
         );
 
         self::assertTrue($container->has('doctrine.migrations.service_migrations_repository'));
+        self::assertTrue($container->has('doctrine.migrations.migrations_finder'));
         self::assertTrue($container->has('doctrine.migrations.connection'));
         self::assertTrue($container->has('doctrine.migrations.logger'));
+    }
+
+    public function testServiceMigrationsFallBackToTheConfiguredMigrationPaths(): void
+    {
+        $config    = [
+            'enable_service_migrations' => true,
+            'migrations_paths' => [
+                'Doctrine\\Bundle\\MigrationsBundle\\Tests\\Fixtures\\ThirdPartyMigrations' => __DIR__ . '/../Fixtures/ThirdPartyMigrations',
+            ],
+        ];
+        $container = $this->getContainer($config);
+        $container->addCompilerPass(new RegisterMigrationsPass());
+
+        $container->register('foo', FooService::class)
+            ->setPublic(true);
+        $container->register(ServiceMigration001::class)
+            ->setAutoconfigured(true)
+            ->setArgument('$fooService', new Reference('foo'));
+        $container->compile();
+
+        $dependencyFactory = $container->get('doctrine.migrations.dependency_factory');
+        assert($dependencyFactory instanceof DependencyFactory);
+
+        $repository = $dependencyFactory->getMigrationRepository();
+        self::assertInstanceOf(ServiceMigrationsRepository::class, $repository);
+
+        $migrations = $repository->getMigrations();
+        self::assertTrue($migrations->hasMigration(new Version(ServiceMigration001::class)));
+        self::assertTrue($migrations->hasMigration(new Version(Version20240101000000::class)));
+        self::assertCount(2, $migrations->getItems());
+
+        self::assertTrue($repository->hasMigration(Version20240101000000::class));
+        self::assertInstanceOf(
+            Version20240101000000::class,
+            $repository->getMigration(new Version(Version20240101000000::class))->getMigration()
+        );
+        $serviceMigration = $repository->getMigration(new Version(ServiceMigration001::class))->getMigration();
+        self::assertInstanceOf(ServiceMigration001::class, $serviceMigration);
+        self::assertSame($container->get('foo'), $serviceMigration->fooService);
     }
 
     public function testEnableServiceMigrationsWhenSetToFalse(): void
@@ -505,6 +547,7 @@ class DoctrineMigrationsExtensionTest extends TestCase
         );
 
         self::assertFalse($container->has('doctrine.migrations.service_migrations_repository'));
+        self::assertFalse($container->has('doctrine.migrations.migrations_finder'));
         self::assertFalse($container->has('doctrine.migrations.connection'));
         self::assertFalse($container->has('doctrine.migrations.logger'));
     }

--- a/tests/Fixtures/ThirdPartyMigrations/Version20240101000000.php
+++ b/tests/Fixtures/ThirdPartyMigrations/Version20240101000000.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\ThirdPartyMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * A migration which is not registered as a service, the way the migrations shipped by third party bundles are.
+ */
+class Version20240101000000 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+    }
+}

--- a/tests/MigrationsRepository/ServiceMigrationFactoryTest.php
+++ b/tests/MigrationsRepository/ServiceMigrationFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsRepository;
+
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationFactory;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class ServiceMigrationFactoryTest extends TestCase
+{
+    public function testReturnsTheServiceWhenTheMigrationIsRegisteredAsAService(): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn(true);
+        $container->method('get')
+            ->with('Version001')
+            ->willReturn($migration);
+
+        $decorated = $this->createMock(MigrationFactory::class);
+        $decorated->expects(self::never())
+            ->method('createVersion');
+
+        $factory = new ServiceMigrationFactory($container, $decorated);
+
+        self::assertSame($migration, $factory->createVersion('Version001'));
+    }
+
+    public function testDelegatesToTheDecoratedFactoryOtherwise(): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn(false);
+        $container->expects(self::never())
+            ->method('get');
+
+        $decorated = $this->createMock(MigrationFactory::class);
+        $decorated->expects(self::once())
+            ->method('createVersion')
+            ->with('Version001')
+            ->willReturn($migration);
+
+        $factory = new ServiceMigrationFactory($container, $decorated);
+
+        self::assertSame($migration, $factory->createVersion('Version001'));
+    }
+}

--- a/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
+++ b/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
@@ -5,10 +5,16 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsRepository;
 
 use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\Migration001;
+use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Configuration\Configuration;
 use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Finder\MigrationFinder;
+use Doctrine\Migrations\Version\MigrationFactory;
 use Doctrine\Migrations\Version\Version;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
 class ServiceMigrationsRepositoryTest extends TestCase
@@ -72,7 +78,7 @@ class ServiceMigrationsRepositoryTest extends TestCase
 
         $container = $this->createMock(ServiceProviderInterface::class);
         $container->method('getProvidedServices')
-            ->willReturn(['Version001', 'Version002']);
+            ->willReturn(['Version001' => '?', 'Version002' => '?']);
         $container->method('has')
             ->willReturn(true);
         $container->method('get')
@@ -86,5 +92,75 @@ class ServiceMigrationsRepositoryTest extends TestCase
         $migrationsSet = $repository->getMigrations();
 
         self::assertCount(2, $migrationsSet->getItems());
+    }
+
+    public function testFallsBackToTheConfiguredMigrationsForMigrationsNotRegisteredAsServices(): void
+    {
+        $serviceMigration    = $this->createMock(AbstractMigration::class);
+        $filesystemMigration = new Migration001($this->createMock(Connection::class), new NullLogger());
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('getProvidedServices')
+            ->willReturn(['Version001' => '?']);
+        $container->method('has')
+            ->willReturnCallback(static function (string $id): bool {
+                return $id === 'Version001';
+            });
+        $container->method('get')
+            ->with('Version001')
+            ->willReturn($serviceMigration);
+
+        $configuration = new Configuration();
+        $configuration->addMigrationsDirectory('Doctrine\\Bundle\\MigrationsBundle\\Tests\\Fixtures\\Migrations', __DIR__ . '/../Fixtures/Migrations');
+
+        $finder = $this->createMock(MigrationFinder::class);
+        $finder->expects(self::once())
+            ->method('findMigrations')
+            ->with(__DIR__ . '/../Fixtures/Migrations', 'Doctrine\\Bundle\\MigrationsBundle\\Tests\\Fixtures\\Migrations')
+            ->willReturn([Migration001::class, 'Version001']);
+
+        $factory = $this->createMock(MigrationFactory::class);
+        $factory->expects(self::once())
+            ->method('createVersion')
+            ->with(Migration001::class)
+            ->willReturn($filesystemMigration);
+
+        $repository = new ServiceMigrationsRepository($container, $configuration, $finder, $factory);
+
+        self::assertTrue($repository->hasMigration('Version001'));
+        self::assertTrue($repository->hasMigration(Migration001::class));
+        self::assertFalse($repository->hasMigration('Version002'));
+
+        self::assertSame($serviceMigration, $repository->getMigration(new Version('Version001'))->getMigration());
+        self::assertSame($filesystemMigration, $repository->getMigration(new Version(Migration001::class))->getMigration());
+
+        $migrationsSet = $repository->getMigrations();
+
+        self::assertCount(2, $migrationsSet->getItems());
+        self::assertSame($serviceMigration, $migrationsSet->getMigration(new Version('Version001'))->getMigration());
+        self::assertSame($filesystemMigration, $migrationsSet->getMigration(new Version(Migration001::class))->getMigration());
+    }
+
+    public function testFallbackThrowsExceptionWhenMigrationClassDoesNotExist(): void
+    {
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('getProvidedServices')
+            ->willReturn([]);
+        $container->method('has')
+            ->willReturn(false);
+
+        $configuration = new Configuration();
+        $configuration->addMigrationClass('NonExistentVersion');
+
+        $repository = new ServiceMigrationsRepository(
+            $container,
+            $configuration,
+            $this->createMock(MigrationFinder::class),
+            $this->createMock(MigrationFactory::class)
+        );
+
+        $this->expectException(MigrationClassNotFound::class);
+
+        $repository->getMigrations();
     }
 }

--- a/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
+++ b/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
@@ -6,6 +6,7 @@ namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsRepository;
 
 use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\Migration001;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ServiceMigration001;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\AbstractMigration;
 use Doctrine\Migrations\Configuration\Configuration;
@@ -94,31 +95,33 @@ class ServiceMigrationsRepositoryTest extends TestCase
         self::assertCount(2, $migrationsSet->getItems());
     }
 
-    public function testFallsBackToTheConfiguredMigrationsForMigrationsNotRegisteredAsServices(): void
+    public function testDelegatesToTheConfiguredMigrationsForMigrationsNotRegisteredAsServices(): void
     {
         $serviceMigration    = $this->createMock(AbstractMigration::class);
         $filesystemMigration = new Migration001($this->createMock(Connection::class), new NullLogger());
 
         $container = $this->createMock(ServiceProviderInterface::class);
         $container->method('getProvidedServices')
-            ->willReturn(['Version001' => '?']);
+            ->willReturn([ServiceMigration001::class => '?']);
         $container->method('has')
             ->willReturnCallback(static function (string $id): bool {
-                return $id === 'Version001';
+                return $id === ServiceMigration001::class;
             });
         $container->method('get')
-            ->with('Version001')
+            ->with(ServiceMigration001::class)
             ->willReturn($serviceMigration);
 
         $configuration = new Configuration();
         $configuration->addMigrationsDirectory('Doctrine\\Bundle\\MigrationsBundle\\Tests\\Fixtures\\Migrations', __DIR__ . '/../Fixtures/Migrations');
 
+        // the project directory is both registered as services and listed in "migrations_paths", as documented
         $finder = $this->createMock(MigrationFinder::class);
         $finder->expects(self::once())
             ->method('findMigrations')
             ->with(__DIR__ . '/../Fixtures/Migrations', 'Doctrine\\Bundle\\MigrationsBundle\\Tests\\Fixtures\\Migrations')
-            ->willReturn([Migration001::class, 'Version001']);
+            ->willReturn([Migration001::class, ServiceMigration001::class]);
 
+        // the migrations registered as services must not be instantiated a second time
         $factory = $this->createMock(MigrationFactory::class);
         $factory->expects(self::once())
             ->method('createVersion')
@@ -127,21 +130,21 @@ class ServiceMigrationsRepositoryTest extends TestCase
 
         $repository = new ServiceMigrationsRepository($container, $configuration, $finder, $factory);
 
-        self::assertTrue($repository->hasMigration('Version001'));
+        self::assertTrue($repository->hasMigration(ServiceMigration001::class));
         self::assertTrue($repository->hasMigration(Migration001::class));
         self::assertFalse($repository->hasMigration('Version002'));
 
-        self::assertSame($serviceMigration, $repository->getMigration(new Version('Version001'))->getMigration());
+        self::assertSame($serviceMigration, $repository->getMigration(new Version(ServiceMigration001::class))->getMigration());
         self::assertSame($filesystemMigration, $repository->getMigration(new Version(Migration001::class))->getMigration());
 
         $migrationsSet = $repository->getMigrations();
 
         self::assertCount(2, $migrationsSet->getItems());
-        self::assertSame($serviceMigration, $migrationsSet->getMigration(new Version('Version001'))->getMigration());
+        self::assertSame($serviceMigration, $migrationsSet->getMigration(new Version(ServiceMigration001::class))->getMigration());
         self::assertSame($filesystemMigration, $migrationsSet->getMigration(new Version(Migration001::class))->getMigration());
     }
 
-    public function testFallbackThrowsExceptionWhenMigrationClassDoesNotExist(): void
+    public function testConfiguredMigrationClassMustExist(): void
     {
         $container = $this->createMock(ServiceProviderInterface::class);
         $container->method('getProvidedServices')


### PR DESCRIPTION
Fixes #680.

Enabling `enable_service_migrations` replaced the migrations repository with one that only knows the migrations registered as services, so the migrations shipped by third party bundles through `migrations_paths` (for example the ones prepended by Sulu) silently disappeared from `doctrine:migrations:status` and `doctrine:migrations:migrate`.

`ServiceMigrationsRepository` now falls back to the configured migration classes and directories for the migrations that are not registered as services, the same way the default repository of doctrine/migrations loads them (through the configured `MigrationFinder` and `MigrationFactory`, without relying on the internal `FilesystemMigrationsRepository`). Migrations registered as services keep precedence when a class is found on both sides, so projects that list their own `src/Migrations` directory in `migrations_paths` still get the service instances.

While at it, the provided service ids are now read from the keys of `getProvidedServices()` (the values are the service types, `?` for services without a known type).

Covered by a unit test of the fallback and an extension test which boots the container with a service migration and a non-service migration directory.
