### PR TITLE
Don't disable filesystem migrations when service migrations are enabled

### DIFF
--- a/config/services.php
+++ b/config/services.php
@@ -6,6 +6,8 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
 use Doctrine\Bundle\MigrationsBundle\EventListener\SchemaFilterListener;
 use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ContainerAwareMigrationFactory;
+use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ServiceMigrationFactory;
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\CompositeMigrationsRepository;
 use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
 use Doctrine\DBAL\Connection;
 use Doctrine\Migrations\Configuration\Configuration;
@@ -15,6 +17,8 @@ use Doctrine\Migrations\Configuration\EntityManager\ExistingEntityManager;
 use Doctrine\Migrations\Configuration\EntityManager\ManagerRegistryEntityManager;
 use Doctrine\Migrations\Configuration\Migration\ExistingConfiguration;
 use Doctrine\Migrations\DependencyFactory;
+use Doctrine\Migrations\FilesystemMigrationsRepository;
+use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Tools\Console\Command\CurrentCommand;
 use Doctrine\Migrations\Tools\Console\Command\DiffCommand;
 use Doctrine\Migrations\Tools\Console\Command\DumpSchemaCommand;
@@ -67,9 +71,22 @@ return static function (ContainerConfigurator $container) {
                 service('service_container'),
             ])
 
+        ->set('doctrine.migrations.service_migrations_factory', ServiceMigrationFactory::class)
+            ->decorate('doctrine.migrations.migrations_factory')
+            ->args([
+                service('doctrine.migrations.service_migrations_factory.inner'),
+                abstract_arg('migrations locator'),
+            ])
+
         ->set('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
             ->args([
                 abstract_arg('migrations locator'),
+            ])
+
+        ->set('doctrine.migrations.composite_migrations_repository', CompositeMigrationsRepository::class)
+            ->args([
+                service('doctrine.migrations.service_migrations_repository'),
+                inline_service()->factory([service('doctrine.migrations.dependency_factory'), 'getMigrationRepository']),
             ])
 
         ->set('doctrine.migrations.connection', Connection::class)

--- a/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
+++ b/src/DependencyInjection/CompilerPass/RegisterMigrationsPass.php
@@ -36,5 +36,8 @@ final class RegisterMigrationsPass implements CompilerPassInterface
 
         $container->getDefinition('doctrine.migrations.service_migrations_repository')
             ->replaceArgument(0, new ServiceLocatorArgument($migrationRefs));
+
+        $container->getDefinition('doctrine.migrations.service_migrations_factory')
+            ->replaceArgument(1, new ServiceLocatorArgument($migrationRefs));
     }
 }

--- a/src/DependencyInjection/DoctrineMigrationsExtension.php
+++ b/src/DependencyInjection/DoctrineMigrationsExtension.php
@@ -56,9 +56,11 @@ class DoctrineMigrationsExtension extends Extension
                 ->addTag('doctrine_migrations.migration');
 
             if (! isset($config['services'][MigrationsRepository::class])) {
-                $config['services'][MigrationsRepository::class] = 'doctrine.migrations.service_migrations_repository';
+                $config['services'][MigrationsRepository::class] = 'doctrine.migrations.composite_migrations_repository';
             }
         } else {
+            $container->removeDefinition('doctrine.migrations.service_migrations_factory');
+            $container->removeDefinition('doctrine.migrations.composite_migrations_repository');
             $container->removeDefinition('doctrine.migrations.service_migrations_repository');
             $container->removeDefinition('doctrine.migrations.connection');
             $container->removeDefinition('doctrine.migrations.logger');

--- a/src/MigrationsFactory/ServiceMigrationFactory.php
+++ b/src/MigrationsFactory/ServiceMigrationFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationsFactory;
+
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+/** @internal */
+final class ServiceMigrationFactory implements MigrationFactory
+{
+    /** @var MigrationFactory */
+    private $migrationFactory;
+
+    /** @var ServiceProviderInterface<AbstractMigration> */
+    private $container;
+
+    /** @param ServiceProviderInterface<AbstractMigration> $container */
+    public function __construct(MigrationFactory $migrationFactory, ServiceProviderInterface $container)
+    {
+        $this->migrationFactory = $migrationFactory;
+        $this->container        = $container;
+    }
+
+    public function createVersion(string $migrationClassName): AbstractMigration
+    {
+        if ($this->container->has($migrationClassName)) {
+            return $this->container->get($migrationClassName);
+        }
+
+        return $this->migrationFactory->createVersion($migrationClassName);
+    }
+}

--- a/src/MigrationsRepository/CompositeMigrationsRepository.php
+++ b/src/MigrationsRepository/CompositeMigrationsRepository.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\MigrationsRepository;
+
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
+use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Version\Version;
+
+use function array_values;
+
+/** @internal */
+final class CompositeMigrationsRepository implements MigrationsRepository
+{
+    /** @var list<MigrationsRepository> */
+    private $migrationRepositories;
+
+    /** @var bool */
+    private $migrationsLoaded = false;
+
+    /** @var array<string, AvailableMigration> */
+    private $migrations = [];
+
+    public function __construct(MigrationsRepository ...$migrationRepositories)
+    {
+        $this->migrationRepositories = array_values($migrationRepositories);
+    }
+
+    public function hasMigration(string $version): bool
+    {
+        foreach ($this->migrationRepositories as $migrationRepository) {
+            if ($migrationRepository->hasMigration($version)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getMigration(Version $version): AvailableMigration
+    {
+        $this->loadMigrations();
+
+        $id = (string) $version;
+
+        if (! isset($this->migrations[$id])) {
+            throw MigrationClassNotFound::new($id);
+        }
+
+        return $this->migrations[$id];
+    }
+
+    public function getMigrations(): AvailableMigrationsSet
+    {
+        $this->loadMigrations();
+
+        return new AvailableMigrationsSet($this->migrations);
+    }
+
+    private function loadMigrations(): void
+    {
+        if ($this->migrationsLoaded) {
+            return;
+        }
+
+        $this->migrationsLoaded = true;
+
+        foreach ($this->migrationRepositories as $migrationRepository) {
+            foreach ($migrationRepository->getMigrations()->getItems() as $migration) {
+                $id                    = (string) $migration->getVersion();
+                $this->migrations[$id] = $this->migrations[$id] ?? $migration;
+            }
+        }
+    }
+}

--- a/src/MigrationsRepository/ServiceMigrationsRepository.php
+++ b/src/MigrationsRepository/ServiceMigrationsRepository.php
@@ -12,6 +12,8 @@ use Doctrine\Migrations\MigrationsRepository;
 use Doctrine\Migrations\Version\Version;
 use Symfony\Contracts\Service\ServiceProviderInterface;
 
+use function array_keys;
+
 /** @internal */
 final class ServiceMigrationsRepository implements MigrationsRepository
 {
@@ -44,7 +46,7 @@ final class ServiceMigrationsRepository implements MigrationsRepository
      */
     public function getMigrations(): AvailableMigrationsSet
     {
-        foreach ($this->container->getProvidedServices() as $id) {
+        foreach (array_keys($this->container->getProvidedServices()) as $id) {
             $this->loadMigrationFromContainer(new Version($id));
         }
 

--- a/tests/DependencyInjection/CompilerPass/RegisterMigrationsPassTest.php
+++ b/tests/DependencyInjection/CompilerPass/RegisterMigrationsPassTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Doctrine\Bundle\MigrationsBundle\Tests\DependencyInjection\CompilerPass;
 
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
+use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ServiceMigrationFactory;
 use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\ServiceMigrationsRepository;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\Migration001;
 use Doctrine\DBAL\Connection;
+use Doctrine\Migrations\Version\MigrationFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Argument\AbstractArgument;
@@ -24,15 +26,23 @@ class RegisterMigrationsPassTest extends TestCase
         $container = new ContainerBuilder();
         $container->register('doctrine.migrations.service_migrations_repository', ServiceMigrationsRepository::class)
             ->addArgument(new AbstractArgument());
+        $container->register('doctrine.migrations.service_migrations_factory', ServiceMigrationFactory::class)
+            ->addArgument(new Reference(MigrationFactory::class))
+            ->addArgument(new AbstractArgument());
         $container->register(Migration001::class, Migration001::class)->addTag('doctrine_migrations.migration');
 
         $pass = new RegisterMigrationsPass();
         $pass->process($container);
 
-        $argument = $container->getDefinition('doctrine.migrations.service_migrations_repository')->getArgument(0);
+        $expectedLocator = new ServiceLocatorArgument([Migration001::class => new TypedReference(Migration001::class, Migration001::class)]);
+
         self::assertEquals(
-            new ServiceLocatorArgument([Migration001::class => new TypedReference(Migration001::class, Migration001::class)]),
-            $argument
+            $expectedLocator,
+            $container->getDefinition('doctrine.migrations.service_migrations_repository')->getArgument(0)
+        );
+        self::assertEquals(
+            $expectedLocator,
+            $container->getDefinition('doctrine.migrations.service_migrations_factory')->getArgument(1)
         );
 
         self::assertEquals([

--- a/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
+++ b/tests/DependencyInjection/DoctrineMigrationsExtensionTest.php
@@ -13,6 +13,8 @@ use Doctrine\Bundle\DoctrineBundle\Registry;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\CompilerPass\RegisterMigrationsPass;
 use Doctrine\Bundle\MigrationsBundle\DependencyInjection\DoctrineMigrationsExtension;
 use Doctrine\Bundle\MigrationsBundle\DoctrineMigrationsBundle;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\FilesystemMigrations\VersionFilesystem001;
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\FilesystemMigrations\VersionFilesystemService001;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ContainerAwareMigration;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Migrations\ServiceMigration001;
 use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services\FooService;
@@ -474,10 +476,12 @@ class DoctrineMigrationsExtensionTest extends TestCase
         self::assertInstanceOf(ServiceMigration001::class, $container->get(ServiceMigration001::class));
 
         self::assertContainsEquals(
-            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.service_migrations_repository'))]],
+            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.composite_migrations_repository'))]],
             $container->getDefinition('doctrine.migrations.dependency_factory')->getMethodCalls()
         );
 
+        self::assertTrue($container->has('doctrine.migrations.service_migrations_factory'));
+        self::assertTrue($container->has('doctrine.migrations.composite_migrations_repository'));
         self::assertTrue($container->has('doctrine.migrations.service_migrations_repository'));
         self::assertTrue($container->has('doctrine.migrations.connection'));
         self::assertTrue($container->has('doctrine.migrations.logger'));
@@ -500,13 +504,48 @@ class DoctrineMigrationsExtensionTest extends TestCase
         self::assertFalse($container->getDefinition(ServiceMigration001::class)->hasTag('doctrine_migrations.migration'));
 
         self::assertNotContainsEquals(
-            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.service_migrations_repository'))]],
+            ['setDefinition', [MigrationsRepository::class, new ServiceClosureArgument(new Reference('doctrine.migrations.composite_migrations_repository'))]],
             $container->getDefinition('doctrine.migrations.dependency_factory')->getMethodCalls()
         );
 
+        self::assertFalse($container->has('doctrine.migrations.service_migrations_factory'));
+        self::assertFalse($container->has('doctrine.migrations.composite_migrations_repository'));
         self::assertFalse($container->has('doctrine.migrations.service_migrations_repository'));
         self::assertFalse($container->has('doctrine.migrations.connection'));
         self::assertFalse($container->has('doctrine.migrations.logger'));
+    }
+
+    public function testServiceMigrationsDoNotDisableFilesystemMigrations(): void
+    {
+        $config    = [
+            'enable_service_migrations' => true,
+            'migrations_paths' => [
+                'Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\FilesystemMigrations' => __DIR__ . '/../Fixtures/FilesystemMigrations',
+            ],
+        ];
+        $container = $this->getContainer($config);
+
+        $container->register('foo', FooService::class);
+        $container->register(VersionFilesystemService001::class)
+            ->setPublic(true)
+            ->setAutoconfigured(true)
+            ->setArgument('$fooService', new Reference('foo'));
+        $container->compile();
+
+        $di = $container->get('doctrine.migrations.dependency_factory');
+        self::assertInstanceOf(DependencyFactory::class, $di);
+
+        $migrations = $di->getMigrationRepository()->getMigrations();
+
+        self::assertCount(2, $migrations->getItems());
+        self::assertInstanceOf(
+            VersionFilesystem001::class,
+            $migrations->getMigration(new Version(VersionFilesystem001::class))->getMigration()
+        );
+        self::assertSame(
+            $container->get(VersionFilesystemService001::class),
+            $migrations->getMigration(new Version(VersionFilesystemService001::class))->getMigration()
+        );
     }
 
     /**

--- a/tests/Fixtures/FilesystemMigrations/VersionFilesystem001.php
+++ b/tests/Fixtures/FilesystemMigrations/VersionFilesystem001.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\FilesystemMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class VersionFilesystem001 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+    }
+}

--- a/tests/Fixtures/FilesystemMigrations/VersionFilesystemService001.php
+++ b/tests/Fixtures/FilesystemMigrations/VersionFilesystemService001.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\FilesystemMigrations;
+
+use Doctrine\Bundle\MigrationsBundle\Tests\Fixtures\Services\FooService;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Psr\Log\LoggerInterface;
+
+class VersionFilesystemService001 extends AbstractMigration
+{
+    /** @var FooService */
+    public $fooService;
+
+    public function __construct(Connection $connection, FooService $fooService, LoggerInterface $logger)
+    {
+        parent::__construct($connection, $logger);
+
+        $this->fooService = $fooService;
+    }
+
+    public function up(Schema $schema): void
+    {
+    }
+}

--- a/tests/MigrationsFactory/ServiceMigrationFactoryTest.php
+++ b/tests/MigrationsFactory/ServiceMigrationFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsFactory;
+
+use Doctrine\Bundle\MigrationsBundle\MigrationsFactory\ServiceMigrationFactory;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Version\MigrationFactory;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Service\ServiceProviderInterface;
+
+class ServiceMigrationFactoryTest extends TestCase
+{
+    public function testCreateVersionReturnsMigrationFromContainer(): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn(true);
+        $container->method('get')
+            ->with('Version001')
+            ->willReturn($migration);
+
+        $decoratedFactory = $this->createMock(MigrationFactory::class);
+        $decoratedFactory->expects(self::never())
+            ->method('createVersion');
+
+        $factory = new ServiceMigrationFactory($decoratedFactory, $container);
+
+        self::assertSame($migration, $factory->createVersion('Version001'));
+    }
+
+    public function testCreateVersionDelegatesToDecoratedFactoryWhenMigrationIsNotAService(): void
+    {
+        $migration = $this->createMock(AbstractMigration::class);
+
+        $container = $this->createMock(ServiceProviderInterface::class);
+        $container->method('has')
+            ->with('Version001')
+            ->willReturn(false);
+        $container->expects(self::never())
+            ->method('get');
+
+        $decoratedFactory = $this->createMock(MigrationFactory::class);
+        $decoratedFactory->expects(self::once())
+            ->method('createVersion')
+            ->with('Version001')
+            ->willReturn($migration);
+
+        $factory = new ServiceMigrationFactory($decoratedFactory, $container);
+
+        self::assertSame($migration, $factory->createVersion('Version001'));
+    }
+}

--- a/tests/MigrationsRepository/CompositeMigrationsRepositoryTest.php
+++ b/tests/MigrationsRepository/CompositeMigrationsRepositoryTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Bundle\MigrationsBundle\Tests\MigrationsRepository;
+
+use Doctrine\Bundle\MigrationsBundle\MigrationsRepository\CompositeMigrationsRepository;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\Migrations\Exception\MigrationClassNotFound;
+use Doctrine\Migrations\Metadata\AvailableMigration;
+use Doctrine\Migrations\Metadata\AvailableMigrationsSet;
+use Doctrine\Migrations\MigrationsRepository;
+use Doctrine\Migrations\Version\Version;
+use PHPUnit\Framework\TestCase;
+
+class CompositeMigrationsRepositoryTest extends TestCase
+{
+    /**
+     * @testWith [true, true]
+     *           [true, false]
+     *           [false, true]
+     */
+    public function testHasMigrationReturnsTrueWhenAnyRepositoryHasIt(bool $first, bool $second): void
+    {
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryHavingMigration($first),
+            $this->createRepositoryHavingMigration($second)
+        );
+
+        self::assertTrue($repository->hasMigration('Version001'));
+    }
+
+    public function testHasMigrationReturnsFalseWhenNoRepositoryHasIt(): void
+    {
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryHavingMigration(false),
+            $this->createRepositoryHavingMigration(false)
+        );
+
+        self::assertFalse($repository->hasMigration('Version001'));
+    }
+
+    public function testGetMigrationReturnsMigrationFromAnyRepository(): void
+    {
+        $migration1 = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+        $migration2 = new AvailableMigration(new Version('Version002'), $this->createMock(AbstractMigration::class));
+
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryWithMigrations($migration1),
+            $this->createRepositoryWithMigrations($migration2)
+        );
+
+        self::assertSame($migration1, $repository->getMigration(new Version('Version001')));
+        self::assertSame($migration2, $repository->getMigration(new Version('Version002')));
+    }
+
+    public function testGetMigrationPrefersEarlierRepositoriesOnDuplicateVersions(): void
+    {
+        $migration1 = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+        $migration2 = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryWithMigrations($migration1),
+            $this->createRepositoryWithMigrations($migration2)
+        );
+
+        self::assertSame($migration1, $repository->getMigration(new Version('Version001')));
+    }
+
+    public function testGetMigrationThrowsExceptionWhenMigrationNotFound(): void
+    {
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryWithMigrations(),
+            $this->createRepositoryWithMigrations()
+        );
+
+        $this->expectException(MigrationClassNotFound::class);
+
+        $repository->getMigration(new Version('NonExistentVersion'));
+    }
+
+    public function testGetMigrationsMergesAllRepositories(): void
+    {
+        $migration1 = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+        $migration2 = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+        $migration3 = new AvailableMigration(new Version('Version002'), $this->createMock(AbstractMigration::class));
+
+        $repository = new CompositeMigrationsRepository(
+            $this->createRepositoryWithMigrations($migration1),
+            $this->createRepositoryWithMigrations($migration2, $migration3)
+        );
+
+        $migrationsSet = $repository->getMigrations();
+
+        self::assertCount(2, $migrationsSet->getItems());
+        self::assertSame($migration1, $migrationsSet->getMigration(new Version('Version001')));
+        self::assertSame($migration3, $migrationsSet->getMigration(new Version('Version002')));
+    }
+
+    public function testRepositoriesAreLoadedOnlyOnce(): void
+    {
+        $migration = new AvailableMigration(new Version('Version001'), $this->createMock(AbstractMigration::class));
+
+        $innerRepository = $this->createMock(MigrationsRepository::class);
+        $innerRepository->expects(self::once())
+            ->method('getMigrations')
+            ->willReturn(new AvailableMigrationsSet([$migration]));
+
+        $repository = new CompositeMigrationsRepository($innerRepository);
+
+        $repository->getMigrations();
+        $repository->getMigrations();
+        $repository->getMigration(new Version('Version001'));
+    }
+
+    private function createRepositoryHavingMigration(bool $hasMigration): MigrationsRepository
+    {
+        $repository = $this->createMock(MigrationsRepository::class);
+        $repository->method('hasMigration')
+            ->with('Version001')
+            ->willReturn($hasMigration);
+
+        return $repository;
+    }
+
+    private function createRepositoryWithMigrations(AvailableMigration ...$migrations): MigrationsRepository
+    {
+        $repository = $this->createMock(MigrationsRepository::class);
+        $repository->method('getMigrations')
+            ->willReturn(new AvailableMigrationsSet($migrations));
+
+        return $repository;
+    }
+}

--- a/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
+++ b/tests/MigrationsRepository/ServiceMigrationsRepositoryTest.php
@@ -72,7 +72,7 @@ class ServiceMigrationsRepositoryTest extends TestCase
 
         $container = $this->createMock(ServiceProviderInterface::class);
         $container->method('getProvidedServices')
-            ->willReturn(['Version001', 'Version002']);
+            ->willReturn(['Version001' => '?', 'Version002' => '?']);
         $container->method('has')
             ->willReturn(true);
         $container->method('get')


### PR DESCRIPTION
Fixes #680, alternative approach to #682.