### PR TITLE
Include symfony/http-kernel v8.0 as requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "symfony/deprecation-contracts": "^2.1 || ^3",
         "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-kernel": "^5.4 || ^6.0 || ^7.0 || ^8.0",
         "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {


### PR DESCRIPTION
Looks like the support for `symfony/http-kernel` v8.0 was not declared in https://github.com/doctrine/DoctrineMigrationsBundle/commit/66d3eba30d9d9337c502dc3eda60230b7b70e62e.

Opened this PR as my previous comment and the follwing-one from @derrabus is not visible on GitHub anymore ... or well, I was not able to see them anymore.

This should allow to keep the discussion saved somewhere :sweat_smile: 